### PR TITLE
Make autopost importable in tests

### DIFF
--- a/autopost/__init__.py
+++ b/autopost/__init__.py
@@ -1,0 +1,5 @@
+"""Autopost package containing utilities for feed handling."""
+
+from .utils import parse_feed, slugify
+
+__all__ = ["parse_feed", "slugify"]

--- a/tests/test_feed_utils.py
+++ b/tests/test_feed_utils.py
@@ -1,7 +1,4 @@
 import pathlib
-import sys
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from autopost.utils import slugify, parse_feed
 

--- a/tests/test_slugify.py
+++ b/tests/test_slugify.py
@@ -1,9 +1,4 @@
-import sys
-import pathlib
-
 import pytest
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from autopost.utils import slugify
 


### PR DESCRIPTION
## Summary
- Make `autopost` a Python package exposing `slugify` and `parse_feed`
- Clean test modules to rely on standard package imports

## Testing
- `python -m pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68b8416da75883338205072e0f5a6f90