### PR TITLE
Refactor autopost hot feed output

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,8 @@
+import pathlib
+import sys
 import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from autopost.common import limit_words_html
 


### PR DESCRIPTION
## Summary
- update the autopost hot feed generator to shard results per parent/subcategory, trim payloads, and derive canonical archive URLs
- add helpers for normalising hot entries, loading existing shards, and enforce per-feed limits before writing data/hot/<parent>/<child>.json
- refresh the pull_news unit tests to expect the new layout and ensure the module path is available during test runs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cece2acae48333ac9e0cc674d626c1