### PR TITLE
feat: add autopost health heartbeat and monitoring

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,7 +8,8 @@ module.exports = function (eleventyConfig) {
     "data",
     "assets",
     "autopost",
-    "_redirects"
+    "_redirects",
+    "_health"
   ];
 
   passthroughPaths.forEach((path) => {

--- a/README.md
+++ b/README.md
@@ -101,6 +101,80 @@ Retention knobs:
 The GitHub Actions workflow `rotate-hot-archive.yml` runs the script on a
 schedule so pruning happens independently of the ingestion jobs.
 
+## Autopost heartbeat & monitoring
+
+Every autopost ingestion run now writes `_health/autopost.json` with a lightweight
+heartbeat payload. The file is refreshed both by `autopost/pull_news.py` and by
+the hot-rotation job so the latest run timestamp survives the nightly pruning
+pass. The JSON schema is:
+
+```json
+{
+  "last_run": "2024-04-18T15:30:00Z",
+  "items_published": 12,
+  "errors": ["fetch_bytes failed: …"]
+}
+```
+
+- `last_run` – UTC timestamp written whenever the job finishes.
+- `items_published` – count of newly published stories (preserved by the
+  rotation task so the ingestion job remains authoritative).
+- `errors` – deduplicated list of warnings or failures observed during the run.
+
+Eleventy copies the `_health/` directory straight into `_site/` so the Netlify
+deployment exposes the heartbeat alongside the rest of the static assets.
+
+### Cloudflare Worker integration
+
+`scripts/monitoring/cloudflare-health-worker.js` contains a Worker that performs
+three duties:
+
+1. Strip caching for requests to `/_health/autopost.json` so consumers always
+   receive a fresh payload.
+2. Inspect the heartbeat on edge fetches (and on a scheduled trigger) to detect
+   stale `last_run` timestamps, low publication counts, or collected errors.
+3. Forward Alertmanager-compatible alerts to a webhook when thresholds are
+   breached.
+
+Configure the Worker with the following environment variables:
+
+- `HEALTH_ORIGIN` – base origin URL that exposes `/_health/autopost.json`.
+- `ALERTMANAGER_WEBHOOK` – Alertmanager receiver URL (optional; monitoring is
+  read-only when omitted).
+- `MIN_ITEMS_PUBLISHED` – minimum acceptable `items_published` before raising a
+  `AutopostLowPublication` alert (default: `1`).
+- `MAX_HEALTH_AGE_MINUTES` – maximum age of `last_run` before emitting an
+  `AutopostStale` alert (default: `120`).
+- `ALERTMANAGER_SERVICE` – label value used for the `service` label in emitted
+  alerts (defaults to `aventuroo-autopost`).
+- `ALERTMANAGER_SEVERITY` / `ALERTMANAGER_SEVERITY_LOW` – optional severity
+  overrides for the generated alerts.
+
+Deploy the Worker via Wrangler (or the Cloudflare dashboard) and attach it to
+the production zone. The Worker will also post alerts when invoked by a
+Cloudflare Cron Trigger, so schedule a job that runs slightly more frequently
+than the acceptable `MAX_HEALTH_AGE_MINUTES` window.
+
+### Alertmanager routing
+
+The Worker sends alerts as a JSON array compatible with Alertmanager’s v2
+webhook. A minimal receiver configuration might look like:
+
+```yaml
+route:
+  receiver: autopost-pager
+  match:
+    service: aventuroo-autopost
+
+receivers:
+  - name: autopost-pager
+    webhook_configs:
+      - url: https://hooks.internal.example/alertmanager
+```
+
+Any downstream Alertmanager template can then fan out notifications (PagerDuty,
+Slack, etc.) when the Worker reports stale data or ingestion failures.
+
 ## Testing
 
 The Python tests validate the shared autopost utilities. Run the full suite

--- a/autopost/health.py
+++ b/autopost/health.py
@@ -1,0 +1,101 @@
+"""Helpers for writing autopost health heartbeat files."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import pathlib
+from typing import Iterable, Sequence
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+HEALTH_DIR = ROOT / "_health"
+
+__all__ = ["HealthReport", "HEALTH_DIR"]
+
+
+def _utc_now_iso() -> str:
+    """Return a second-precision UTC timestamp with a ``Z`` suffix."""
+
+    return _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def _coerce_errors(messages: Sequence[str], *, limit: int = 20) -> list[str]:
+    """Clean and deduplicate error strings while preserving order."""
+
+    seen: set[str] = set()
+    cleaned: list[str] = []
+    for raw in messages:
+        text = str(raw or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        cleaned.append(text)
+        if len(cleaned) >= limit:
+            break
+    return cleaned
+
+
+def _load_existing(path: pathlib.Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError:
+        return {}
+
+
+class HealthReport:
+    """Accumulate run errors and persist them to ``_health/<name>.json``."""
+
+    def __init__(self, name: str, *, health_dir: pathlib.Path | None = None) -> None:
+        self.name = name
+        self.health_dir = health_dir or HEALTH_DIR
+        self.errors: list[str] = []
+        self._items_override: int | None = None
+
+    # Public API ---------------------------------------------------------
+    def record_error(self, message: str) -> None:
+        text = str(message or "").strip()
+        if text:
+            self.errors.append(text)
+
+    def extend_errors(self, messages: Iterable[str]) -> None:
+        for message in messages:
+            self.record_error(str(message))
+
+    def set_items_published(self, value: int | None) -> None:
+        if value is None:
+            self._items_override = None
+        else:
+            try:
+                coerced = int(value)
+            except (TypeError, ValueError):
+                coerced = 0
+            self._items_override = max(0, coerced)
+
+    def write(self, *, items_published: int | None = None) -> pathlib.Path:
+        if items_published is not None:
+            self.set_items_published(items_published)
+
+        path = self.health_dir / f"{self.name}.json"
+        existing = _load_existing(path)
+
+        if self._items_override is not None:
+            items_value = self._items_override
+        else:
+            existing_value = existing.get("items_published")
+            try:
+                items_value = int(existing_value)
+            except (TypeError, ValueError):
+                items_value = 0
+            items_value = max(0, items_value)
+
+        payload = {
+            "last_run": _utc_now_iso(),
+            "items_published": items_value,
+            "errors": _coerce_errors(self.errors),
+        }
+
+        self.health_dir.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        return path

--- a/scripts/monitoring/cloudflare-health-worker.js
+++ b/scripts/monitoring/cloudflare-health-worker.js
@@ -1,0 +1,239 @@
+const HEALTH_PATH = "/_health/autopost.json";
+const DEFAULT_MIN_ITEMS = 1;
+const DEFAULT_MAX_AGE_MINUTES = 120;
+const MAX_ERROR_LINES = 3;
+
+const NO_CACHE_HEADERS = {
+  "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+  "CDN-Cache-Control": "no-store",
+  "Surrogate-Control": "no-store",
+  Pragma: "no-cache"
+};
+
+function parseInteger(value, fallback) {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  const parsed = parseInt(String(value), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function buildAlert(env, alertName, summary, description, severityOverride) {
+  const now = new Date().toISOString();
+  const severity = severityOverride || env.ALERTMANAGER_SEVERITY || "critical";
+  const service = env.ALERTMANAGER_SERVICE || "aventuroo-autopost";
+  return {
+    labels: {
+      alertname: alertName,
+      service,
+      severity
+    },
+    annotations: {
+      summary,
+      description
+    },
+    startsAt: now
+  };
+}
+
+async function sendAlerts(alerts, env) {
+  if (!alerts.length || !env.ALERTMANAGER_WEBHOOK) {
+    return;
+  }
+
+  try {
+    await fetch(env.ALERTMANAGER_WEBHOOK, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(alerts)
+    });
+  } catch (error) {
+    console.error("Failed to send alerts to Alertmanager", error);
+  }
+}
+
+function withNoCacheHeaders(response) {
+  const forwarded = new Response(response.body, response);
+  for (const [key, value] of Object.entries(NO_CACHE_HEADERS)) {
+    forwarded.headers.set(key, value);
+  }
+  return forwarded;
+}
+
+function resolveOriginUrl(requestUrl, env) {
+  if (!env.HEALTH_ORIGIN) {
+    return new URL(requestUrl);
+  }
+  const origin = new URL(env.HEALTH_ORIGIN);
+  const url = new URL(requestUrl);
+  url.protocol = origin.protocol;
+  url.hostname = origin.hostname;
+  url.port = origin.port;
+  return url;
+}
+
+async function fetchFromOrigin(request, env) {
+  const originUrl = resolveOriginUrl(request.url, env);
+  const init = {
+    method: request.method,
+    headers: new Headers(request.headers)
+  };
+
+  if (env.HEALTH_ORIGIN) {
+    init.headers.set("host", originUrl.hostname);
+  }
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = request.body;
+  }
+
+  const originRequest = new Request(originUrl.toString(), init);
+  return fetch(originRequest, {
+    cf: {
+      cacheTtl: 0,
+      cacheEverything: false,
+      cacheKey: undefined
+    }
+  });
+}
+
+function evaluateMetrics(data, env) {
+  const alerts = [];
+  const now = new Date();
+  const minItems = parseInteger(env.MIN_ITEMS_PUBLISHED, DEFAULT_MIN_ITEMS);
+  const maxAgeMinutes = parseInteger(env.MAX_HEALTH_AGE_MINUTES, DEFAULT_MAX_AGE_MINUTES);
+
+  const items = Number(data.items_published);
+  if (!Number.isFinite(items) || items < minItems) {
+    alerts.push(
+      buildAlert(
+        env,
+        "AutopostLowPublication",
+        `Autopost published ${items} items`,
+        `Minimum expected items is ${minItems}, received ${items}`,
+        env.ALERTMANAGER_SEVERITY_LOW || env.ALERTMANAGER_SEVERITY || "critical"
+      )
+    );
+  }
+
+  const lastRunRaw = data.last_run;
+  const lastRun = lastRunRaw ? new Date(lastRunRaw) : null;
+  if (!lastRun || Number.isNaN(lastRun.getTime())) {
+    alerts.push(
+      buildAlert(
+        env,
+        "AutopostMissingTimestamp",
+        "Autopost last_run timestamp missing",
+        `Payload contained last_run=${JSON.stringify(lastRunRaw)}`
+      )
+    );
+  } else {
+    const diffMinutes = Math.abs(now.getTime() - lastRun.getTime()) / 60000;
+    if (diffMinutes > maxAgeMinutes) {
+      alerts.push(
+        buildAlert(
+          env,
+          "AutopostStale",
+          `Autopost last ran ${Math.round(diffMinutes)} minutes ago`,
+          `Maximum allowed freshness is ${maxAgeMinutes} minutes`
+        )
+      );
+    }
+  }
+
+  const errors = Array.isArray(data.errors) ? data.errors.filter(Boolean) : [];
+  if (errors.length) {
+    const displayed = errors.slice(0, MAX_ERROR_LINES).join("\n");
+    const extra = errors.length > MAX_ERROR_LINES ? ` (and ${errors.length - MAX_ERROR_LINES} more)` : "";
+    alerts.push(
+      buildAlert(
+        env,
+        "AutopostErrors",
+        "Autopost run reported errors",
+        `${displayed}${extra}`,
+        env.ALERTMANAGER_SEVERITY || "critical"
+      )
+    );
+  }
+
+  return alerts;
+}
+
+async function processHealthResponse(response, env) {
+  const alerts = [];
+
+  if (!response) {
+    alerts.push(
+      buildAlert(env, "AutopostHealthUnavailable", "Autopost health unavailable", "No response from origin")
+    );
+    await sendAlerts(alerts, env);
+    return alerts;
+  }
+
+  if (!response.ok) {
+    const description = `Origin responded with status ${response.status}`;
+    alerts.push(buildAlert(env, "AutopostHealthHttpError", "Autopost health request failed", description));
+    await sendAlerts(alerts, env);
+    return alerts;
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    alerts.push(
+      buildAlert(env, "AutopostHealthParseError", "Failed to parse autopost health payload", String(error))
+    );
+    await sendAlerts(alerts, env);
+    return alerts;
+  }
+
+  const metricAlerts = evaluateMetrics(payload, env);
+  alerts.push(...metricAlerts);
+  await sendAlerts(alerts, env);
+  return alerts;
+}
+
+async function runScheduledHealthCheck(env) {
+  if (!env.HEALTH_ORIGIN) {
+    console.warn("HEALTH_ORIGIN not configured; skipping scheduled health check");
+    return;
+  }
+
+  try {
+    const base = new URL(env.HEALTH_ORIGIN);
+    base.pathname = HEALTH_PATH;
+    const response = await fetch(base.toString(), {
+      headers: { Accept: "application/json" },
+      cf: { cacheTtl: 0, cacheEverything: false }
+    });
+    await processHealthResponse(response, env);
+  } catch (error) {
+    const alert = buildAlert(
+      env,
+      "AutopostHealthFetchError",
+      "Scheduled health check failed",
+      String(error)
+    );
+    await sendAlerts([alert], env);
+    console.error("Scheduled autopost health check failed", error);
+  }
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    if (url.pathname === HEALTH_PATH) {
+      const originResponse = await fetchFromOrigin(request, env);
+      const cloned = originResponse.clone();
+      ctx.waitUntil(processHealthResponse(cloned, env));
+      return withNoCacheHeaders(originResponse);
+    }
+
+    return fetch(request);
+  },
+
+  async scheduled(event, env, ctx) {
+    ctx.waitUntil(runScheduledHealthCheck(env));
+  }
+};


### PR DESCRIPTION
## Summary
- add a reusable `HealthReport` helper that persists `_health/autopost.json`
- teach the news autoposter and rotation script to record metrics/errors and emit heartbeat updates
- copy the `_health` directory during Eleventy builds, document the heartbeat, and add a Cloudflare Worker for Alertmanager hooks

## Testing
- python -m unittest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef15a55e08333af9f1e2c5c67130a