### PR TITLE
Ensure autopost workflow syncs branch head

### DIFF
--- a/.github/workflows/autopost.yml
+++ b/.github/workflows/autopost.yml
@@ -93,6 +93,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Sync branch head
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin
+          git reset --hard "origin/${GITHUB_REF_NAME:-${GITHUB_HEAD_REF:-main}}"
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -169,6 +176,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Sync branch head
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin
+          git reset --hard "origin/${GITHUB_REF_NAME:-${GITHUB_HEAD_REF:-main}}"
+
       - name: Download autopost states
         uses: actions/download-artifact@v4
         with:
@@ -196,6 +210,5 @@ jobs:
             echo "No changes."
           else
             git commit -m "autopost: update content"
-            git pull --rebase origin "${GITHUB_REF_NAME:-${GITHUB_HEAD_REF:-main}}" || true
-            git push
+            git push origin "HEAD:${GITHUB_REF_NAME:-${GITHUB_HEAD_REF:-main}}"
           fi


### PR DESCRIPTION
## Summary
- add explicit branch sync in the autopost ingest and commit jobs so each run tracks the branch head
- simplify the commit step to push directly after syncing with the remote head

## Testing
- manual dry-run of two sequential ingest matrix entries with local feed fixtures to confirm posts and hot shards persist across runs (`CATEGORY=Dryrun FEEDS_FILE=autopost/feeds_dryrun*.txt python autopost/pull_news.py`)


------
https://chatgpt.com/codex/tasks/task_e_68cf01b5725c8333b561d990239d3193