### PR TITLE
Add sync steps to content refresh workflow

### DIFF
--- a/.github/workflows/content-refresh.yml
+++ b/.github/workflows/content-refresh.yml
@@ -1,0 +1,108 @@
+name: Content Refresh
+
+on:
+  workflow_dispatch: {}
+  workflow_run:
+    workflows:
+      - Autopost
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  rotate:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      rotation_changed: ${{ steps.git_push.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync branch head
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin
+          git reset --hard "origin/${GITHUB_REF_NAME:-${GITHUB_HEAD_REF:-main}}"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Rotate hot shards into archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/rotate_hot_to_archive.py 2>&1 | tee rotation.log
+
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit rotation changes
+        id: git_push
+        shell: bash
+        run: |
+          set -euo pipefail
+          git add -A
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No rotation changes detected."
+          else
+            git commit -m "chore: rotate hot shards"
+            git push origin "HEAD:${GITHUB_REF_NAME:-${GITHUB_HEAD_REF:-main}}"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload rotation log
+        uses: actions/upload-artifact@v4
+        with:
+          name: rotation-log
+          retention-days: 7
+          path: rotation.log
+
+  build:
+    needs: rotate
+    runs-on: ubuntu-latest
+    if: needs.rotate.result == 'success'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync branch head
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin
+          git reset --hard "origin/${GITHUB_REF_NAME:-${GITHUB_HEAD_REF:-main}}"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Compress site assets
+        run: npm run postbuild
+
+      - name: Upload Eleventy build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: eleventy-site
+          retention-days: 7
+          path: |
+            _site
+            _health
+            data


### PR DESCRIPTION
## Summary
- add a dedicated content refresh workflow with rotation and build jobs
- sync each job with the latest branch head before running rotation or builds
- capture rotation output, commit updates, and publish Eleventy artifacts

## Testing
- `PYTHONPATH=. python scripts/rotate_hot_to_archive.py --dry-run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cf04150e588333b77b28b85e340487