### PR TITLE
Fix navigation links to use category template

### DIFF
--- a/src/site/_includes/partials/footer.njk
+++ b/src/site/_includes/partials/footer.njk
@@ -11,7 +11,7 @@
             <p class="brand-description">
               AventurOO — Top News, Tech &amp; AI, Travel &amp; Deals.
             </p>
-            <a href="{{ '/about-us.html' | url }}" class="btn btn-magz white">About Us <i class="ion-ios-arrow-thin-right"></i></a>
+            <a href="{{ '/page.html' | url }}" class="btn btn-magz white">About Us <i class="ion-ios-arrow-thin-right"></i></a>
           </div>
         </div>
       </div>
@@ -68,7 +68,7 @@
           <div class="block-body no-margin">
             <ul class="footer-nav-horizontal">
               <li><a href="{{ '/' | url }}">Home</a></li>
-              <li><a href="#">Partner</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=business-finance">Partner</a></li>
               <li><a href="{{ '/page.html' | url }}">About</a></li>
             </ul>
           </div>

--- a/src/site/_includes/partials/header.njk
+++ b/src/site/_includes/partials/header.njk
@@ -63,56 +63,56 @@
           <li><a href="{{ '/' | url }}">HOME</a></li>
 
           <li class="dropdown magz-dropdown">
-            <a href="{{ '/news/index.html' | url }}">News <i class="ion-ios-arrow-right"></i></a>
+            <a href="{{ '/category.html' | url }}?cat=news">News <i class="ion-ios-arrow-right"></i></a>
             <ul class="dropdown-menu">
-              <li><a href="{{ '/news/top-stories.html' | url }}">Top Stories</a></li>
-              <li><a href="{{ '/news/politics.html' | url }}">Politics</a></li>
-              <li><a href="{{ '/news/economy.html' | url }}">Economy</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=top-stories">Top Stories</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=politics">Politics</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=economy">Economy</a></li>
               <li class="dropdown magz-dropdown">
-                <a href="{{ '/business-finance/index.html' | url }}">Business &amp; Finance <i class="ion-ios-arrow-right"></i></a>
+                <a href="{{ '/category.html' | url }}?cat=business-finance">Business &amp; Finance <i class="ion-ios-arrow-right"></i></a>
                 <ul class="dropdown-menu">
-                  <li><a href="{{ '/business-finance/markets-economy.html' | url }}">Markets &amp; Economy</a></li>
-                  <li><a href="{{ '/business-finance/companies-startups.html' | url }}">Companies &amp; Startups</a></li>
-                  <li><a href="{{ '/business-finance/personal-finance.html' | url }}">Personal Finance</a></li>
+                  <li><a href="{{ '/category.html' | url }}?cat=markets-economy">Markets &amp; Economy</a></li>
+                  <li><a href="{{ '/category.html' | url }}?cat=companies-startups">Companies &amp; Startups</a></li>
+                  <li><a href="{{ '/category.html' | url }}?cat=personal-finance">Personal Finance</a></li>
                 </ul>
               </li>
             </ul>
           </li>
 
-          <li class="dropdown magz-dropdown magz-dropdown-megamenu"><a href="{{ '/tech-ai/index.html' | url }}">Tech &amp; AI <i class="ion-ios-arrow-right"></i></a>
+          <li class="dropdown magz-dropdown magz-dropdown-megamenu"><a href="{{ '/category.html' | url }}?cat=tech-ai">Tech &amp; AI <i class="ion-ios-arrow-right"></i></a>
             <div class="dropdown-menu megamenu">
               <div class="megamenu-inner">
                 <div class="row">
                   <div class="col-md-3">
                     <h2 class="megamenu-title">AI &amp; BIG TECH</h2>
                     <ul class="vertical-menu">
-                      <li><a href="{{ '/tech-ai/ai-news' | url }}">AI News</a></li>
-                      <li><a href="{{ '/tech-ai/big-tech' | url }}">Big Tech</a></li>
+                      <li><a href="{{ '/category.html' | url }}?cat=ai-news">AI News</a></li>
+                      <li><a href="{{ '/category.html' | url }}?cat=big-tech">Big Tech</a></li>
                     </ul>
                   </div>
                   <div class="col-md-3">
                     <h2 class="megamenu-title">INNOVATION</h2>
                     <ul class="vertical-menu">
-                      <li><a href="{{ '/tech-ai/innovation-gadgets' | url }}">Innovation &amp; Gadgets</a></li>
-                      <li><a href="{{ '/tech-ai/gaming-tech' | url }}">Gaming Tech / AI Gaming</a></li>
+                      <li><a href="{{ '/category.html' | url }}?cat=innovation-gadgets">Innovation &amp; Gadgets</a></li>
+                      <li><a href="{{ '/category.html' | url }}?cat=gaming-tech">Gaming Tech / AI Gaming</a></li>
                     </ul>
                   </div>
                   <div class="col-md-3">
                     <h2 class="megamenu-title">SECURITY</h2>
                     <ul class="vertical-menu">
-                      <li><a href="{{ '/tech-ai/security-privacy' | url }}">Security &amp; Privacy</a></li>
-                      <li><a href="{{ '/tech-ai/internet-platforms' | url }}">Internet &amp; Platforms</a></li>
+                      <li><a href="{{ '/category.html' | url }}?cat=security-privacy">Security &amp; Privacy</a></li>
+                      <li><a href="{{ '/category.html' | url }}?cat=internet-platforms">Internet &amp; Platforms</a></li>
                       <h2 class="megamenu-title">Creator</h2>
-                      <li><a href="{{ '/tech-ai/audio-creator-tools' | url }}">Audio &amp; Creator Tools</a></li>
+                      <li><a href="{{ '/category.html' | url }}?cat=audio-creator">Audio &amp; Creator Tools</a></li>
                     </ul>
                   </div>
                   <div class="col-md-3">
                     <h2 class="megamenu-title">CRYPTO</h2>
                     <ul class="vertical-menu">
-                      <li><a href="{{ '/crypto/bitcoin-majors' | url }}">Bitcoin &amp; Majors</a></li>
-                      <li><a href="{{ '/crypto/altcoins-web3' | url }}">Altcoins &amp; Web3</a></li>
-                      <li><a href="{{ '/crypto/regulation-security' | url }}">Regulation &amp; Security</a></li>
-                      <li><a href="{{ '/crypto/guides-crypto' | url }}">Guides Crypto</a></li>
+                      <li><a href="{{ '/category.html' | url }}?cat=bitcoin-majors">Bitcoin &amp; Majors</a></li>
+                      <li><a href="{{ '/category.html' | url }}?cat=altcoins-web3">Altcoins &amp; Web3</a></li>
+                      <li><a href="{{ '/category.html' | url }}?cat=regulation-security">Regulation &amp; Security</a></li>
+                      <li><a href="{{ '/category.html' | url }}?cat=guides">Guides Crypto</a></li>
                     </ul>
                   </div>
                 </div>
@@ -121,70 +121,70 @@
           </li>
 
           <li class="dropdown magz-dropdown">
-            <a href="{{ '/entertainment/index.html' | url }}">Entertainment <i class="ion-ios-arrow-right"></i></a>
+            <a href="{{ '/category.html' | url }}?cat=entertainment">Entertainment <i class="ion-ios-arrow-right"></i></a>
             <ul class="dropdown-menu">
-              <li><a href="{{ '/entertainment/movies.html' | url }}">Movies</a></li>
-              <li><a href="{{ '/entertainment/tv-streaming.html' | url }}">TV-Streaming</a></li>
-              <li><a href="{{ '/entertainment/trailers.html' | url }}">Trailers</a></li>
-              <li><a href="{{ '/entertainment/cinematography.html' | url }}">Cinematography</a></li>
-              <li><a href="{{ '/entertainment/history-essays.html' | url }}">History &amp; Essays</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=movies">Movies</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=tv-streaming">TV-Streaming</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=trailers">Trailers</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=cinematography">Cinematography</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=history-essays">History &amp; Essays</a></li>
             </ul>
           </li>
 
           <li class="dropdown magz-dropdown">
-            <a href="{{ '/lifestyle/index.html' | url }}">Lifestyle <i class="ion-ios-arrow-right"></i></a>
+            <a href="{{ '/category.html' | url }}?cat=lifestyle">Lifestyle <i class="ion-ios-arrow-right"></i></a>
             <ul class="dropdown-menu">
-              <li><a href="{{ '/lifestyle/health.html' | url }}">Health</a></li>
-              <li><a href="{{ '/lifestyle/beauty-style.html' | url }}">Beauty &amp; Style</a></li>
-              <li><a href="{{ '/lifestyle/home-design.html' | url }}">Home &amp; Design</a></li>
-              <li><a href="{{ '/lifestyle/inspiration.html' | url }}">Inspiration</a></li>
-              <li><a href="{{ '/lifestyle/outdoor.html' | url }}">Outdoor</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=health">Health</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=beauty-style">Beauty &amp; Style</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=home-design">Home &amp; Design</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=inspiration">Inspiration</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=outdoor">Outdoor</a></li>
               <li class="dropdown magz-dropdown">
-                <a href="{{ '/food-drink/index.html' | url }}">Food &amp; Drink <i class="ion-ios-arrow-right"></i></a>
+                <a href="{{ '/category.html' | url }}?cat=food-drink">Food &amp; Drink <i class="ion-ios-arrow-right"></i></a>
                 <ul class="dropdown-menu">
-                  <li><a href="{{ '/food-drink/food.html' | url }}">Food</a></li>
-                  <li><a href="{{ '/food-drink/drink.html' | url }}">Drink</a></li>
-                  <li><a href="{{ '/food-drink/guides.html' | url }}">Guides</a></li>
+                  <li><a href="{{ '/category.html' | url }}?cat=food">Food</a></li>
+                  <li><a href="{{ '/category.html' | url }}?cat=drink">Drink</a></li>
+                  <li><a href="{{ '/category.html' | url }}?cat=guides">Guides</a></li>
                 </ul>
               </li>
             </ul>
           </li>
 
           <li class="dropdown magz-dropdown">
-            <a href="{{ '/travel/index.html' | url }}">Travel <i class="ion-ios-arrow-right"></i></a>
+            <a href="{{ '/category.html' | url }}?cat=travel">Travel <i class="ion-ios-arrow-right"></i></a>
             <ul class="dropdown-menu">
-              <li><a href="{{ '/travel/trip-ideas.html' | url }}">Trip Ideas</a></li>
-              <li><a href="{{ '/travel/destinations.html' | url }}">Destinations</a></li>
-              <li><a href="{{ '/travel/tips-planning.html' | url }}">Tips &amp; Planning</a></li>
-              <li><a href="{{ '/travel/stays.html' | url }}">Stays (Hotels)</a></li>
-              <li><a href="{{ '/travel/experiences.html' | url }}">Experiences</a></li>
-              <li><a href="{{ '/travel/transport.html' | url }}">Transport</a></li>
-              <li><a href="{{ '/travel/things-to-do.html' | url }}">Things To Do</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=trip-ideas">Trip Ideas</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=destinations">Destinations</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=tips-planning">Tips &amp; Planning</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=stays-hotels">Stays (Hotels)</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=experiences">Experiences</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=transport">Transport</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=things-to-do">Things To Do</a></li>
             </ul>
           </li>
 
           <li class="dropdown magz-dropdown">
-            <a href="{{ '/culture-arts/index.html' | url }}">Culture &amp; Arts <i class="ion-ios-arrow-right"></i></a>
+            <a href="{{ '/category.html' | url }}?cat=culture-arts">Culture &amp; Arts <i class="ion-ios-arrow-right"></i></a>
             <ul class="dropdown-menu">
-              <li><a href="{{ '/culture-arts/culture.html' | url }}">Culture</a></li>
-              <li><a href="{{ '/culture-arts/arts.html' | url }}">Arts</a></li>
-              <li><a href="{{ '/culture-arts/history.html' | url }}">History</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=culture">Culture</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=arts">Arts</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=history">History</a></li>
             </ul>
           </li>
 
           <li class="dropdown magz-dropdown">
-            <a href="{{ '/shopping/index.html' | url }}">Shopping <i class="ion-ios-arrow-right"></i></a>
+            <a href="{{ '/category.html' | url }}?cat=shopping">Shopping <i class="ion-ios-arrow-right"></i></a>
             <ul class="dropdown-menu">
-              <li><a href="{{ '/shopping/tech-deals.html' | url }}">Tech Deals</a></li>
-              <li><a href="{{ '/shopping/subscriptions.html' | url }}">Subscriptions</a></li>
-              <li><a href="{{ '/shopping/travel-deals.html' | url }}">Travel Deals</a></li>
-              <li><a href="{{ '/shopping/vpn-security.html' | url }}">VPN &amp; Security</a></li>
-              <li><a href="{{ '/shopping/marketplaces.html' | url }}">Marketplaces</a></li>
-              <li><a href="{{ '/shopping/multi-merchant-networks.html' | url }}">Multi-merchant Networks</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=tech-deals">Tech Deals</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=subscriptions">Subscriptions</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=travel-deals">Travel Deals</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=vpn-security">VPN &amp; Security</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=marketplaces">Marketplaces</a></li>
+              <li><a href="{{ '/category.html' | url }}?cat=multi-merchant">Multi-merchant Networks</a></li>
             </ul>
           </li>
 
-          <li><a href="{{ '/about-us.html' | url }}">About Us </a></li>
+          <li><a href="{{ '/page.html' | url }}">About Us </a></li>
 
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- replace static header URLs with category.html links that match the slugs defined in menu.json
- update footer buttons to point to existing pages instead of placeholder targets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf10e204e083338d8e65869353141b