### PR TITLE
Load dynamic menu script in base layout

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -16,10 +16,10 @@
     var ctn = $('#menu-list');
     var srcAttr = ctn ? ctn.getAttribute('data-menu-src') : null;
     var list = [];
-    if (srcAttr) list.push(srcAttr);␊
-    list.push('data/menu.json', '/data/menu.json');␊
+    if (srcAttr) list.push(srcAttr);
+    list.push('data/menu.json', '/data/menu.json');
     return basePath.resolveAll ? basePath.resolveAll(list) : list;
-  }␊
+  }
 
   function fetchSequential(urls) {
     return new Promise(function(resolve, reject){
@@ -78,7 +78,7 @@
         var ul = el('ul', 'vertical-menu');
         col.links.forEach(function (lnk) {
           var li = document.createElement('li');
-          li.appendChild(buildLink({ title: lnk.title, href: lnk.href || '#', target: lnk.target }));␊
+          li.appendChild(buildLink({ title: lnk.title, href: lnk.href || '#', target: lnk.target }));
           ul.appendChild(li);
         });
         c.appendChild(ul);
@@ -126,9 +126,9 @@
     var liTitle = el('li', 'for-tablet nav-title');
     liTitle.appendChild(el('a', null, cfg.title || 'Menu'));
     var liLogin = el('li', 'for-tablet');
-    liLogin.appendChild(buildLink({ title: 'Login', href: cfg.loginHref || 'login.html' }));␊
-    var liRegister = el('li', 'for-tablet');␊
-    liRegister.appendChild(buildLink({ title: 'Register', href: cfg.registerHref || 'register.html' }));␊
+    liLogin.appendChild(buildLink({ title: 'Login', href: cfg.loginHref || 'login.html' }));
+    var liRegister = el('li', 'for-tablet');
+    liRegister.appendChild(buildLink({ title: 'Register', href: cfg.registerHref || 'register.html' }));
     root.appendChild(liTitle);
     root.appendChild(liLogin);
     root.appendChild(liRegister);
@@ -187,10 +187,10 @@
       .then(renderMenu)
       .catch(function (err) {
         console.error('Menu load error:', err);
-        renderMenu({␊
-          tabletHeader: { show: true },␊
+        renderMenu({
+          tabletHeader: { show: true },
           items: [{ title: 'Home', href: basePath.resolve ? basePath.resolve('/') : 'index.html' }]
-        });␊
-      });␊
-  });␊
-})();␊
+        });
+      });
+  });
+})();

--- a/src/site/_includes/layouts/base.njk
+++ b/src/site/_includes/layouts/base.njk
@@ -46,6 +46,7 @@
       window.__AVENTUROO_BASE_PATH__ = "{{ basePath | default('') | escape }}";
     </script>
     <script src="{{ '/js/base-path.js' | url }}"></script>
+    <script src="{{ '/js/menu.js' | url }}"></script>
     <script src="{{ '/js/jquery.js' | url }}"></script>
     <script src="{{ '/js/jquery.migrate.js' | url }}"></script>
     <script src="{{ '/js/footer-latest.js' | url }}"></script>


### PR DESCRIPTION
## Summary
- include `menu.js` after `base-path.js` in the base layout so the dynamic navigation script runs when pages load
- clean up stray control characters in `js/menu.js` so the passthrough file executes without syntax errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf1620e74c8333a16503183c569eb7