### PR TITLE
Constrain pip upgrade in Autopost workflow

### DIFF
--- a/.github/workflows/autopost.yml
+++ b/.github/workflows/autopost.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade 'pip<24.3'
           pip install trafilatura readability-lxml lxml certifi
 
       - name: Restore autopost state marker


### PR DESCRIPTION
## Summary
- constrain the Autopost workflow's pip upgrade to versions below 24.3 to avoid breaking changes

## Testing
- not run (workflow execution requires GitHub Actions environment)

------
https://chatgpt.com/codex/tasks/task_e_68cf1d1794dc8333aefac489835d6fdb