### PR TITLE
Update article links to use slug-based article page

### DIFF
--- a/js/articles.json
+++ b/js/articles.json
@@ -4,7 +4,7 @@
     "category": "Film",
     "date": "December 19, 2016",
     "image": "images/news/img11.jpg",
-    "link": "single.html",
+    "link": "article.html?slug=taylor-swift-s-latest-showgirl-look-is-another-bob-mackie-masterpiece-2025-09-20",
     "excerpt": "Donec consequat, arcu at ultrices sodales, quam erat aliquet diam, sit amet interdum libero nunc accumsan nisi."
   },
   {
@@ -12,7 +12,7 @@
     "category": "Travel",
     "date": "December 18, 2016",
     "image": "images/news/img02.jpg",
-    "link": "single.html",
+    "link": "article.html?slug=dua-lipa-shimmers-in-a-beaded-gucci-skirt-that-proves-florals-are-for-fall-2025-09-20",
     "excerpt": "Maecenas accumsan tortor ut velit pharetra mollis. Proin eu nisl et arcu iaculis placerat sollicitudin ut est. In fringilla dui."
   },
   {
@@ -20,7 +20,7 @@
     "category": "Healthy",
     "date": "December 16, 2016",
     "image": "images/news/img09.jpg",
-    "link": "single.html",
+    "link": "article.html?slug=luxury-apartment-living-off-road-and-off-grid-capability-noovo-next-campervan-2025-09-20",
     "excerpt": "Maecenas blandit ultricies lorem, id tempor enim pulvinar at. Curabitur sit amet tortor eu ipsum lacinia malesuada. Etiam sed vulputate magna."
   }
 ]

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -2,5 +2,6 @@ module.exports = {
   name: "AventurOO",
   description: "AventurOO curates top stories across news, technology & AI, travel inspiration, culture, lifestyle tips, and shopping deals in one streamlined hub.",
   url: "https://aventuroo.com",
-  author: "AventurOO"
+  author: "AventurOO",
+  adFallbackSlug: "luxury-apartment-living-off-road-and-off-grid-capability-noovo-next-campervan-2025-09-20"
 };

--- a/src/site/article.njk
+++ b/src/site/article.njk
@@ -81,7 +81,7 @@ permalink: article.html
                         <aside id="sidebar-top-ad">
                           <div class="aside-body">
                             <figure class="ads">
-                              <a href="{{ '/single.html' | url }}">
+                              <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
                                 <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
                               </a>
                               <figcaption>Advertisement</figcaption>
@@ -97,7 +97,7 @@ permalink: article.html
                         <aside id="sidebar-second-ad">
                           <div class="aside-body">
                             <figure class="ads">
-                              <a href="{{ '/single.html' | url }}">
+                              <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
                                 <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
                               </a>
                               <figcaption>Advertisement</figcaption>
@@ -113,7 +113,7 @@ permalink: article.html
                         <aside id="sidebar-third-ad">
                           <div class="aside-body">
                             <figure class="ads">
-                              <a href="{{ '/single.html' | url }}">
+                              <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
                                 <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
                               </a>
                               <figcaption>Advertisement</figcaption>

--- a/src/site/category.njk
+++ b/src/site/category.njk
@@ -35,7 +35,7 @@ permalink: category.html
                         <aside id="sidebar-top-ad">
                           <div class="aside-body">
                             <figure class="ads">
-                              <a href="{{ '/single.html' | url }}">
+                              <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
                                 <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
                               </a>
                               <figcaption>Advertisement</figcaption>
@@ -51,7 +51,7 @@ permalink: category.html
                         <aside id="sidebar-second-ad">
                           <div class="aside-body">
                             <figure class="ads">
-                              <a href="{{ '/single.html' | url }}">
+                              <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
                                 <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
                               </a>
                               <figcaption>Advertisement</figcaption>
@@ -67,7 +67,7 @@ permalink: category.html
                         <aside id="sidebar-third-ad">
                           <div class="aside-body">
                             <figure class="ads">
-                              <a href="{{ '/single.html' | url }}">
+                              <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
                                 <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
                               </a>
                               <figcaption>Advertisement</figcaption>

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -1,6 +1,11 @@
 ---
 layout: layouts/base.njk
 permalink: index.html
+featuredFallbackSlugs:
+  - opinion-robert-redford-will-always-light-up-our-screens-2025-09-20
+  - scientists-uncover-exercise-s-secret-hunger-busting-molecule-2025-09-20
+  - scientists-discover-cancer-s-hidden-power-to-accelerate-aging-2025-09-20
+  - sabrina-carpenter-goes-back-to-basics-with-a-look-fit-for-a-country-music-star-2025-09-20
 ---
 <section class="home">
         <div class="container">
@@ -32,7 +37,7 @@ permalink: index.html
                                                         </figure>
                                                         <div class="details">
                                                                 <div class="category"><a href="category.html">Computer</a></div>
-                                                                <h1><a href="single.html">Phasellus iaculis quam sed est elementum vel ornare ligula venenatis</a></h1>
+                                                                <h1><a href="{{ '/article.html' | url }}?slug={{ featuredFallbackSlugs[0] | urlencode }}">Phasellus iaculis quam sed est elementum vel ornare ligula venenatis</a></h1>
                                                                 <div class="time">December 26, 2016</div>
                                                         </div>
                                                 </article>
@@ -45,7 +50,7 @@ permalink: index.html
                                                         </figure>
                                                         <div class="details">
                                                                 <div class="category"><a href="category.html">Travel</a></div>
-                                                                <h1><a href="single.html">Class aptent taciti sociosqu ad litora torquent per conubia nostra</a></h1>
+                                                                <h1><a href="{{ '/article.html' | url }}?slug={{ featuredFallbackSlugs[1] | urlencode }}">Class aptent taciti sociosqu ad litora torquent per conubia nostra</a></h1>
                                                                 <div class="time">December 10, 2016</div>
                                                         </div>
                                                 </article>
@@ -58,7 +63,7 @@ permalink: index.html
                                                         </figure>
                                                         <div class="details">
                                                                 <div class="category"><a href="category.html">International</a></div>
-                                                                <h1><a href="single.html">Maecenas accumsan tortor ut velit pharetra mollis</a></h1>
+                                                                <h1><a href="{{ '/article.html' | url }}?slug={{ featuredFallbackSlugs[2] | urlencode }}">Maecenas accumsan tortor ut velit pharetra mollis</a></h1>
                                                                 <div class="time">October 12, 2016</div>
                                                         </div>
                                                 </article>
@@ -71,7 +76,7 @@ permalink: index.html
                                                         </figure>
                                                         <div class="details">
                                                                 <div class="category"><a href="category.html">Lifestyle</a></div>
-                                                                <h1><a href="single.html">Mauris elementum libero at pharetra auctor Fusce ullamcorper elit</a></h1>
+                                                                <h1><a href="{{ '/article.html' | url }}?slug={{ featuredFallbackSlugs[3] | urlencode }}">Mauris elementum libero at pharetra auctor Fusce ullamcorper elit</a></h1>
                                                                 <div class="time">November 27, 2016</div>
                                                         </div>
                                                 </article>
@@ -176,7 +181,7 @@ permalink: index.html
         <aside id="sidebar-top-ad">
           <div class="aside-body">
             <figure class="ads">
-              <a href="{{ '/single.html' | url }}">
+              <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
                 <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
               </a>
               <figcaption>Advertisement</figcaption>
@@ -193,7 +198,7 @@ permalink: index.html
         <aside id="sidebar-third-ad">
           <div class="aside-body">
             <figure class="ads">
-              <a href="{{ '/single.html' | url }}">
+              <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
                 <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
               </a>
               <figcaption>Advertisement</figcaption>


### PR DESCRIPTION
## Summary
- update home page featured cards and ad spots to point at article.html with representative slugs
- reuse a shared ad fallback slug in article and category sidebars
- point the example articles dataset at article.html slug URLs for dynamic components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf1c483e748333bad0519df326b2b0