### PR TITLE
Ensure rotate script finds project root

### DIFF
--- a/scripts/rotate_hot_to_archive.py
+++ b/scripts/rotate_hot_to_archive.py
@@ -41,6 +41,11 @@ from collections import defaultdict
 from email.utils import parsedate_to_datetime
 from typing import Any, Iterable, Iterator, Optional
 
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_PROJECT_ROOT_STR = str(PROJECT_ROOT)
+if _PROJECT_ROOT_STR not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT_STR)
+
 from autopost.health import HealthReport
 
 


### PR DESCRIPTION
## Summary
- ensure the rotate hot to archive script inserts the project root onto sys.path so the autopost package imports reliably

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf22e9d5b48333a660916e6b2667d1