### PR TITLE
Add standalone execution guard to rotate_hot_to_archive

### DIFF
--- a/scripts/rotate_hot_to_archive.py
+++ b/scripts/rotate_hot_to_archive.py
@@ -41,6 +41,9 @@ from collections import defaultdict
 from email.utils import parsedate_to_datetime
 from typing import Any, Iterable, Iterator, Optional
 
+if __package__ in (None, ""):
+    sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
 from autopost.health import HealthReport
 
 


### PR DESCRIPTION
## Summary
- add a __package__ guard so rotate_hot_to_archive can adjust sys.path when run directly

## Testing
- python scripts/rotate_hot_to_archive.py --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68cf23a9dee88333a35f1a878c384599