### PR TITLE
Normalize Food & Drink feed categories

### DIFF
--- a/autopost/feeds_food_drink.txt
+++ b/autopost/feeds_food_drink.txt
@@ -1,18 +1,18 @@
 # === FOOD & DRINK / GENERAL ===
-Food & Drink|food-drink|https://www.delish.com/rss/all.xml/
-Food & Drink|food-drink|https://www.tasteofhome.com/feed/
+Food & Drink|General|https://www.delish.com/rss/all.xml/
+Food & Drink|General|https://www.tasteofhome.com/feed/
 
 # === FOOD ===
-Food|food|https://www.bonappetit.com/feed/rss
-Food|food|https://smittenkitchen.com/feed/
-Food|food|https://cookieandkate.com/feed/
-Food|food|https://pinchofyum.com/feed
+Food & Drink|Food|https://www.bonappetit.com/feed/rss
+Food & Drink|Food|https://smittenkitchen.com/feed/
+Food & Drink|Food|https://cookieandkate.com/feed/
+Food & Drink|Food|https://pinchofyum.com/feed
 
 # === DRINK ===
-Drink|drink|https://imbibemagazine.com/feed/
-Drink|drink|https://vinepair.com/feed/
-Drink|drink|https://punchdrink.com/feed/
-Drink|drink|https://www.thedrinksbusiness.com/feed/
-Drink|drink|https://www.cocktailenthusiast.com/feed/
-Drink|drink|https://brewbound.com/feed/
+Food & Drink|Drink|https://imbibemagazine.com/feed/
+Food & Drink|Drink|https://vinepair.com/feed/
+Food & Drink|Drink|https://punchdrink.com/feed/
+Food & Drink|Drink|https://www.thedrinksbusiness.com/feed/
+Food & Drink|Drink|https://www.cocktailenthusiast.com/feed/
+Food & Drink|Drink|https://brewbound.com/feed/
 


### PR DESCRIPTION
## Summary
- ensure every Food & Drink feed entry uses the parent category in the first field
- promote the section name (General, Food, Drink) into the second field for the feeds file

## Testing
- python autopost/pull_food_drink.py *(fails: feed fetches blocked by 403 responses in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf23e7485c83338a0fd5c1542cb16b