### PR TITLE
Document autopost hot shard rotation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,12 @@ Retention knobs:
 - `HOT_PAGINATION_SIZE` – pagination size used when computing manifest counts
   (default: `12`).
 
-The GitHub Actions workflow `rotate-hot-archive.yml` runs the script on a
-schedule so pruning happens independently of the ingestion jobs.
+In day-to-day operation the rotation happens automatically. The
+`.github/workflows/autopost.yml` workflow runs on a staggered cron schedule and
+each matrix job finishes by calling the "Rotate hot shards into archive" step,
+which executes `scripts/rotate_hot_to_archive.py` immediately after the ingest
+scripts complete. That keeps the hot shards trimmed without requiring a separate
+maintenance workflow, while still allowing manual execution for ad-hoc cleanup.
 
 ## Autopost heartbeat & monitoring
 


### PR DESCRIPTION
## Summary
- update the hot shard rotation docs to note the autopost workflow handles the rotation via its scheduled runs

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf2aed82348333895315e58140c156