### PR TITLE
Simplify autopost schedule cron

### DIFF
--- a/.github/workflows/autopost.yml
+++ b/.github/workflows/autopost.yml
@@ -3,8 +3,7 @@ name: Autopost
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "0 0,3,6,9,12,15,18,21 * * *"
-    - cron: "30 1,4,7,10,13,16,19,22 * * *"
+    - cron: "0 */3 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- reduce the autopost workflow schedule to a single cron entry that runs every three hours starting at midnight UTC

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf3454249c8333a3c1abf1fc2ebfd0