### PR TITLE
Implement dynamic autopost limits

### DIFF
--- a/.github/workflows/autopost.yml
+++ b/.github/workflows/autopost.yml
@@ -26,68 +26,58 @@ jobs:
             script: pull_news.py
             feeds: autopost/feeds_news.txt
             category: News
-            max_per_cat: "10"
             summary_words: "900"
             order: "01"
           - name: "Business & Finance"
             script: pull_news.py
             feeds: autopost/feeds_news.txt
             category: "Business & Finance"
-            max_per_cat: "10"
             summary_words: "900"
             order: "02"
           - name: Crypto
             script: pull_crypto.py
             feeds: autopost/feeds_crypto.txt
             category: Crypto
-            max_per_cat: "5"
             summary_words: "900"
             order: "03"
           - name: Culture & Arts
             script: pull_cultute_arts.py
             feeds: autopost/feeds_cultute_arts.txt
             category: "Culture & Arts"
-            max_per_cat: "10"
             summary_words: "900"
             order: "04"
           - name: Entertainment
             script: pull_entertainment.py
             feeds: autopost/feeds_entertainment.txt
             category: Entertainment
-            max_per_cat: "10"
             summary_words: "900"
             order: "05"
           - name: Food & Drink
             script: pull_food_drink.py
             feeds: autopost/feeds_food_drink.txt
             category: "Food & Drink"
-            max_per_cat: "10"
             summary_words: "900"
             order: "06"
           - name: Lifestyle
             script: pull_lifestyle.py
             feeds: autopost/feeds_lifestyle.txt
             category: Lifestyle
-            max_per_cat: "10"
             summary_words: "900"
             order: "07"
           - name: Tech & AI
             script: pull_tech_ai.py
             feeds: autopost/feeds_tech_ai.txt
             category: "Tech & AI"
-            max_per_cat: "10"
             summary_words: "900"
             order: "08"
           - name: Travel
             script: pull_travel.py
             feeds: autopost/feeds_travel.txt
             category: Travel
-            max_per_cat: "10"
             summary_words: "900"
             order: "09"
     env:
       SUMMARY_WORDS: ${{ matrix.summary_words }}
-      MAX_PER_CAT: ${{ matrix.max_per_cat }}
       HTTP_TIMEOUT: "18"
       AP_USER_AGENT: "Mozilla/5.0 (AventurOO Autoposter)"
       FALLBACK_COVER: "assets/img/cover-fallback.jpg"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Environment variables recognised by the scripts include:
 
 - `FEEDS_FILE` – override the bundled feeds list.
 - `CATEGORY` – restrict processing to one category.
-- `MAX_PER_CAT`, `MAX_TOTAL`, `MAX_POSTS_PERSIST` – tune quantity limits.
+- `MAX_PER_FEED`, `MAX_TOTAL`, `MAX_POSTS_PERSIST` – tune quantity limits. Per-subcategory caps are now derived from `feed_count × per-feed cap` (5 by default, 10 when marked important).
 - `FALLBACK_COVER`, `DEFAULT_AUTHOR`, `IMG_PROXY`, etc. – control cover images
   and metadata.
 - `HOT_MAX_ITEMS`, `HOT_PAGINATION_SIZE` – size the hot shard payloads that


### PR DESCRIPTION
## Summary
- parse the feeds file into reusable feed specs, track per-subcategory feed counts, and derive per-feed caps from inline markers or section comments before computing per-category limits
- enforce the derived per-feed and per-category caps when ingesting feeds so important subcategories can publish up to ten posts per feed while defaulting to five
- document the dynamic behaviour and drop the MAX_PER_CAT wiring from the autopost workflow matrix

## Testing
- python -m compileall autopost/pull_news.py
- FEEDS_FILE=tmp/autopost_test/feeds_test.txt CATEGORY=Test MAX_TOTAL=0 python autopost/pull_news.py

------
https://chatgpt.com/codex/tasks/task_e_68cf34dc62e8833386405c9f50f0a28f