### PR TITLE
feat: derive dynamic autopost category limits

### DIFF
--- a/.github/workflows/autopost.yml
+++ b/.github/workflows/autopost.yml
@@ -25,68 +25,58 @@ jobs:
             script: pull_news.py
             feeds: autopost/feeds_news.txt
             category: News
-            max_per_cat: "10"
             summary_words: "900"
             order: "01"
           - name: "Business & Finance"
             script: pull_news.py
             feeds: autopost/feeds_news.txt
             category: "Business & Finance"
-            max_per_cat: "10"
             summary_words: "900"
             order: "02"
           - name: Crypto
             script: pull_crypto.py
             feeds: autopost/feeds_crypto.txt
             category: Crypto
-            max_per_cat: "5"
             summary_words: "900"
             order: "03"
           - name: Culture & Arts
             script: pull_cultute_arts.py
             feeds: autopost/feeds_cultute_arts.txt
             category: "Culture & Arts"
-            max_per_cat: "10"
             summary_words: "900"
             order: "04"
           - name: Entertainment
             script: pull_entertainment.py
             feeds: autopost/feeds_entertainment.txt
             category: Entertainment
-            max_per_cat: "10"
             summary_words: "900"
             order: "05"
           - name: Food & Drink
             script: pull_food_drink.py
             feeds: autopost/feeds_food_drink.txt
             category: "Food & Drink"
-            max_per_cat: "10"
             summary_words: "900"
             order: "06"
           - name: Lifestyle
             script: pull_lifestyle.py
             feeds: autopost/feeds_lifestyle.txt
             category: Lifestyle
-            max_per_cat: "10"
             summary_words: "900"
             order: "07"
           - name: Tech & AI
             script: pull_tech_ai.py
             feeds: autopost/feeds_tech_ai.txt
             category: "Tech & AI"
-            max_per_cat: "10"
             summary_words: "900"
             order: "08"
           - name: Travel
             script: pull_travel.py
             feeds: autopost/feeds_travel.txt
             category: Travel
-            max_per_cat: "10"
             summary_words: "900"
             order: "09"
     env:
       SUMMARY_WORDS: ${{ matrix.summary_words }}
-      MAX_PER_CAT: ${{ matrix.max_per_cat }}
       HTTP_TIMEOUT: "18"
       AP_USER_AGENT: "Mozilla/5.0 (AventurOO Autoposter)"
       FALLBACK_COVER: "assets/img/cover-fallback.jpg"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ Environment variables recognised by the scripts include:
 
 - `FEEDS_FILE` – override the bundled feeds list.
 - `CATEGORY` – restrict processing to one category.
-- `MAX_PER_CAT`, `MAX_TOTAL`, `MAX_POSTS_PERSIST` – tune quantity limits.
+- `MAX_PER_FEED`, `MAX_TOTAL`, `MAX_POSTS_PERSIST` – tune quantity limits.
+- Per-subcategory limits are now derived from feed counts. Add `max=10` or
+  `importance=high` metadata (either as an extra `|key=value` field or in the
+  preceding header comment) to raise a subcategory's per-feed cap to 10.
 - `FALLBACK_COVER`, `DEFAULT_AUTHOR`, `IMG_PROXY`, etc. – control cover images
   and metadata.
 - `HOT_MAX_ITEMS`, `HOT_PAGINATION_SIZE` – size the hot shard payloads that


### PR DESCRIPTION
## Summary
- compute per-subcategory feed statistics (count + cap) from the feeds file, honouring `max=`/`importance=high` metadata and driving per-feed/per-category limits dynamically
- replace the fixed `MAX_PER_CAT` guard in the autoposter with feed-count × cap logic and document the new behaviour
- drop the `MAX_PER_CAT` matrix wiring in the autopost workflow now that per-category totals are derived automatically

## Testing
- FEEDS_FILE=/tmp/test_feeds.txt CATEGORY="Test Category" MAX_TOTAL=40 python autopost/pull_news.py
- FEEDS_FILE=/tmp/test_feeds.txt CATEGORY="Test Category" MAX_TOTAL=40 python autopost/pull_news.py  # rerun to ensure no regressions
- FEEDS_FILE=/tmp/test_feeds.txt CATEGORY="Test Category" MAX_TOTAL=40 python autopost/pull_news.py  # rerun until zero new posts

------
https://chatgpt.com/codex/tasks/task_e_68cf3694ff40833382ab94777153aea2