### PR TITLE
Add server-rendered monthly archive pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -28,6 +28,125 @@ module.exports = function (eleventyConfig) {
     }
   });
 
+  eleventyConfig.addFilter("padNumber", (value, length = 2) => {
+    const size = Number.isFinite(length) && length > 0 ? Math.floor(length) : 2;
+    const number = Number.parseInt(value, 10);
+    if (Number.isFinite(number)) {
+      return String(Math.abs(number)).padStart(size, "0");
+    }
+    const stringValue = value == null ? "" : String(value);
+    if (stringValue.length >= size) {
+      return stringValue;
+    }
+    return stringValue.padStart(size, "0");
+  });
+
+  const ARCHIVE_ACRONYMS = new Set([
+    "AI",
+    "AR",
+    "ETF",
+    "EV",
+    "EVS",
+    "IPO",
+    "NFT",
+    "TV",
+    "UK",
+    "US",
+    "UAE",
+    "VPN",
+    "VR"
+  ]);
+
+  eleventyConfig.addFilter("formatArchiveLabel", (value) => {
+    if (value == null) {
+      return "";
+    }
+
+    const normalized = String(value)
+      .replace(/[-_]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    if (!normalized) {
+      return "";
+    }
+
+    return normalized.split(" ").map((word) => {
+      if (!word) {
+        return "";
+      }
+
+      const alpha = word.replace(/[^a-zA-Z]/g, "");
+      if (alpha && ARCHIVE_ACRONYMS.has(alpha.toUpperCase())) {
+        return alpha.toUpperCase();
+      }
+
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    }).join(" ");
+  });
+
+  eleventyConfig.addFilter("formatArchiveMonth", (monthValue, yearValue) => {
+    const monthNumber = Number.parseInt(monthValue, 10);
+    const yearNumber = Number.parseInt(yearValue, 10);
+
+    if (Number.isFinite(monthNumber) && Number.isFinite(yearNumber)) {
+      const date = new Date(Date.UTC(yearNumber, monthNumber - 1, 1));
+      if (!Number.isNaN(date.valueOf())) {
+        try {
+          return date.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+        } catch (error) {
+          // Ignore locale errors and fall through to fallback formatting.
+        }
+      }
+      return `${yearNumber}-${String(monthNumber).padStart(2, "0")}`;
+    }
+
+    if (yearValue && monthValue) {
+      return `${yearValue}-${String(monthValue).padStart(2, "0")}`;
+    }
+
+    return String(yearValue || monthValue || "");
+  });
+
+  eleventyConfig.addFilter("formatArchiveDate", (value) => {
+    if (!value) {
+      return "";
+    }
+
+    const date = new Date(value);
+    if (!Number.isNaN(date.valueOf())) {
+      try {
+        return date.toLocaleDateString("en-US", {
+          year: "numeric",
+          month: "long",
+          day: "numeric"
+        });
+      } catch (error) {
+        // Ignore locale errors and fall through to fallback formatting.
+      }
+    }
+
+    if (typeof value === "string" && value.match(/^\d{4}-\d{2}-\d{2}$/)) {
+      const parts = value.split("-");
+      return `${parts[0]}-${parts[1]}-${parts[2]}`;
+    }
+
+    return String(value);
+  });
+
+  eleventyConfig.addFilter("archiveHost", (urlValue) => {
+    if (!urlValue) {
+      return "";
+    }
+
+    try {
+      const url = new URL(urlValue, "https://example.com");
+      return url.hostname.replace(/^www\./i, "");
+    } catch (error) {
+      return "";
+    }
+  });
+
   return {
     dir: {
       input: "src/site",

--- a/css/style.css
+++ b/css/style.css
@@ -4226,6 +4226,224 @@ blockquote {
   color: rgba(25, 30, 33, 0.6);
   font-size: 18px;
 }
+.archive-month__header .archive__title {
+  letter-spacing: 3px;
+}
+.archive-month__breadcrumbs {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 0 0 12px;
+  font-size: 13px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: rgba(25, 30, 33, 0.55);
+}
+.archive-month__breadcrumbs a {
+  font-weight: 700;
+  color: #F73F52;
+}
+.archive-month__breadcrumbs a:hover,
+.archive-month__breadcrumbs a:focus {
+  color: #C8081C;
+}
+.archive-month__layout {
+  display: grid;
+  gap: 40px;
+}
+.archive-month__main {
+  display: grid;
+  gap: 28px;
+}
+.archive-month__stories {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 24px;
+}
+.archive-month__story {
+  margin: 0;
+}
+.archive-month__card {
+  background-color: #fff;
+  border-radius: 18px;
+  box-shadow: 0 25px 60px rgba(25, 30, 33, 0.08);
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+}
+.archive-month__media {
+  background: rgba(25, 30, 33, 0.04);
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+.archive-month__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.archive-month__content {
+  padding: 24px 30px 30px;
+  display: grid;
+  gap: 14px;
+}
+.archive-month__story-title {
+  margin: 0;
+  font-size: 26px;
+  line-height: 1.3;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.archive-month__story-title a {
+  color: #191E21;
+}
+.archive-month__story-title a:hover,
+.archive-month__story-title a:focus {
+  color: #C8081C;
+}
+.archive-month__excerpt {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.7;
+  color: rgba(25, 30, 33, 0.75);
+}
+.archive-month__meta {
+  margin: 0;
+  display: grid;
+  gap: 6px;
+  font-size: 14px;
+}
+.archive-month__meta div {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: baseline;
+}
+.archive-month__meta dt {
+  margin: 0;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 1.6px;
+  color: rgba(25, 30, 33, 0.6);
+}
+.archive-month__meta dd {
+  margin: 0;
+  color: rgba(25, 30, 33, 0.75);
+}
+.archive-month__meta a {
+  color: #F73F52;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.3px;
+  font-size: 12px;
+}
+.archive-month__meta a:hover,
+.archive-month__meta a:focus {
+  color: #C8081C;
+}
+.archive-month__empty {
+  background-color: #fff;
+  border-radius: 18px;
+  box-shadow: 0 25px 60px rgba(25, 30, 33, 0.08);
+  padding: 40px 32px;
+  text-align: center;
+  font-size: 18px;
+  line-height: 1.7;
+  color: rgba(25, 30, 33, 0.68);
+  display: grid;
+  gap: 16px;
+}
+.archive-month__pagination {
+  text-align: center;
+  display: grid;
+  gap: 8px;
+  font-size: 15px;
+  color: rgba(25, 30, 33, 0.7);
+}
+.archive-month__pagination p {
+  margin: 0;
+}
+.archive-month__note {
+  font-size: 14px;
+  color: rgba(25, 30, 33, 0.6);
+  line-height: 1.6;
+}
+.archive-month__sidebar {
+  display: grid;
+  gap: 24px;
+}
+.archive-month__panel {
+  background-color: #fff;
+  border-radius: 18px;
+  box-shadow: 0 25px 60px rgba(25, 30, 33, 0.08);
+  padding: 28px 30px;
+  display: grid;
+  gap: 18px;
+}
+.archive-month__panel-title {
+  margin: 0;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+.archive-month__stats {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+.archive-month__stats div {
+  display: grid;
+  gap: 4px;
+}
+.archive-month__stats dt {
+  margin: 0;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 1.6px;
+  color: rgba(25, 30, 33, 0.6);
+}
+.archive-month__stats dd {
+  margin: 0;
+  font-size: 16px;
+  color: rgba(25, 30, 33, 0.85);
+}
+.archive-month__links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+.archive-month__links a {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.6px;
+  color: #F73F52;
+}
+.archive-month__links a:hover,
+.archive-month__links a:focus {
+  color: #C8081C;
+}
+@media (min-width: 992px) {
+  .archive-month__layout {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+@media (max-width: 767px) {
+  .archive-month__content {
+    padding: 20px;
+  }
+  .archive-month__panel {
+    padding: 24px;
+  }
+}
 @media (max-width: 767px) {
   .archive {
     padding: 40px 0 60px;

--- a/src/site/_data/archiveManifest.js
+++ b/src/site/_data/archiveManifest.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+
+function readJson(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    if (!content) return null;
+    return JSON.parse(content);
+  } catch (error) {
+    return null;
+  }
+}
+
+function padNumber(value, length) {
+  const number = Number.parseInt(value, 10);
+  if (Number.isFinite(number)) {
+    return String(Math.abs(number)).padStart(length, '0');
+  }
+  return String(value == null ? '' : value).padStart(length, '0');
+}
+
+module.exports = function archiveManifestData() {
+  const rootDir = path.resolve(__dirname, '..', '..', '..');
+  const archiveDir = path.join(rootDir, 'data', 'archive');
+  const manifestPath = path.join(archiveDir, 'manifest.json');
+
+  const manifest = readJson(manifestPath) || {};
+  const shards = Array.isArray(manifest.shards) ? manifest.shards : [];
+
+  const processed = shards.map((shard) => {
+    const parent = shard && typeof shard.parent === 'string' ? shard.parent : '';
+    const child = shard && typeof shard.child === 'string' ? shard.child : '';
+    const year = shard && shard.year != null ? shard.year : '';
+    const month = shard && shard.month != null ? shard.month : '';
+
+    const yearString = padNumber(year, 4);
+    const monthString = padNumber(month, 2);
+
+    const shardPath = path.join(archiveDir, parent, child, yearString, monthString, 'index.json');
+    const shardData = readJson(shardPath);
+    const items = Array.isArray(shardData && shardData.items) ? shardData.items : [];
+    const pagination = shardData && typeof shardData.pagination === 'object' ? shardData.pagination : null;
+    const updatedAt = shardData && (shardData.updated_at || shardData.updatedAt || null);
+
+    let count = items.length;
+    if (shardData && typeof shardData.count === 'number') {
+      count = shardData.count;
+    } else if (typeof shard.items === 'number') {
+      count = shard.items;
+    }
+
+    const dataHref = '/' + path.posix.join('data', 'archive', parent, child, yearString, monthString, 'index.json');
+    let gzipHref = null;
+    if (shard && typeof shard.path_gz === 'string' && shard.path_gz.trim()) {
+      const gzipRelative = shard.path_gz.replace(/\\/g, '/').replace(/^\/+/, '');
+      gzipHref = '/' + path.posix.join('data', 'archive', gzipRelative);
+    }
+
+    return {
+      ...shard,
+      parent,
+      child,
+      year,
+      month,
+      yearString,
+      monthString,
+      stories: items,
+      pagination,
+      updatedAt,
+      count,
+      dataHref,
+      gzipHref,
+      dataMissing: !shardData
+    };
+  });
+
+  return {
+    generated_at: manifest.generated_at || null,
+    per_page: manifest.per_page || null,
+    total_items: manifest.total_items || 0,
+    shards: processed
+  };
+};

--- a/src/site/archive-month.njk
+++ b/src/site/archive-month.njk
@@ -1,0 +1,185 @@
+---
+layout: layouts/base.njk
+pagination:
+  data: archiveManifest.shards
+  size: 1
+  alias: archiveEntry
+permalink: false
+eleventyComputed:
+  permalink: "archive/{{ archiveEntry.parent }}/{{ archiveEntry.child }}/{{ archiveEntry.yearString }}/{{ archiveEntry.monthString }}/index.html"
+  title: "{{ archiveEntry.child | formatArchiveLabel }} Archive — {{ archiveEntry.month | formatArchiveMonth(archiveEntry.year) }} | AventurOO"
+  description: "Browse archived {{ archiveEntry.child | formatArchiveLabel }} stories from {{ archiveEntry.month | formatArchiveMonth(archiveEntry.year) }}."
+  parentLabel: "{{ archiveEntry.parent | formatArchiveLabel }}"
+  childLabel: "{{ archiveEntry.child | formatArchiveLabel }}"
+  monthLabel: "{{ archiveEntry.month | formatArchiveMonth(archiveEntry.year) }}"
+  og_title: "{{ archiveEntry.child | formatArchiveLabel }} Archive — {{ archiveEntry.month | formatArchiveMonth(archiveEntry.year) }}"
+  og_url: "https://aventuroo.com/archive/{{ archiveEntry.parent }}/{{ archiveEntry.child }}/{{ archiveEntry.yearString }}/{{ archiveEntry.monthString }}/"
+---
+{% set entry = archiveEntry %}
+{% set stories = entry.stories or [] %}
+{% set storiesCount = stories | length %}
+{% set paginationInfo = entry.pagination %}
+{% set categorySlug = entry.child %}
+{% if categorySlug == 'index' and entry.parent and entry.parent != 'index' %}
+  {% set categorySlug = entry.parent %}
+{% endif %}
+<section class="archive archive-month">
+  <div class="container">
+    <header class="archive__header archive-month__header">
+      <p class="archive-month__breadcrumbs" aria-label="Archive breadcrumb">
+        <a href="{{ '/archive.html' | url }}">Archive</a>
+        <span aria-hidden="true">/</span>
+        <span>{{ entry.parent | formatArchiveLabel }}</span>
+        <span aria-hidden="true">/</span>
+        <span>{{ entry.child | formatArchiveLabel }}</span>
+      </p>
+      <h1 class="archive__title">{{ entry.month | formatArchiveMonth(entry.year) }}</h1>
+      <p class="archive__description">
+        Archived stories from {{ entry.child | formatArchiveLabel }} in {{ entry.month | formatArchiveMonth(entry.year) }}.
+      </p>
+    </header>
+
+    <div class="archive-month__layout">
+      <div class="archive-month__main">
+        {% if storiesCount %}
+          <ol class="archive-month__stories">
+            {% for story in stories %}
+              <li class="archive-month__story">
+                <article class="archive-month__card">
+                  {% if story.cover %}
+                  <div class="archive-month__media">
+                    <img src="{{ story.cover | escape }}" alt="{{ story.title or 'Story cover image' }}" loading="lazy">
+                  </div>
+                  {% endif %}
+                  <div class="archive-month__content">
+                    <h2 class="archive-month__story-title">
+                      {% set storyUrl = story.canonical or story.archive_url or story.url %}
+                      {% if storyUrl %}
+                        <a href="{{ storyUrl | escape }}">{{ story.title or 'Untitled story' }}</a>
+                      {% else %}
+                        {{ story.title or 'Untitled story' }}
+                      {% endif %}
+                    </h2>
+                    {% if story.excerpt %}
+                      <p class="archive-month__excerpt">{{ story.excerpt }}</p>
+                    {% endif %}
+                    <dl class="archive-month__meta">
+                      {% if story.date %}
+                        <div>
+                          <dt>Published</dt>
+                          <dd>{{ story.date | formatArchiveDate }}</dd>
+                        </div>
+                      {% endif %}
+                      {% set sourceUrl = story.source or storyUrl %}
+                      {% if sourceUrl %}
+                        <div>
+                          <dt>Source</dt>
+                          <dd><a href="{{ sourceUrl | escape }}">{{ sourceUrl | archiveHost }}</a></dd>
+                        </div>
+                      {% endif %}
+                    </dl>
+                  </div>
+                </article>
+              </li>
+            {% endfor %}
+          </ol>
+        {% elseif entry.dataMissing %}
+          <div class="archive-month__empty">
+            <p>The archived data for this month is temporarily unavailable.</p>
+            <p>Please review the <a href="{{ entry.dataHref }}">source JSON</a> for the latest updates.</p>
+          </div>
+        {% else %}
+          <div class="archive-month__empty">
+            <p>No archived stories were found for this month.</p>
+            <p>Check back soon or explore other months from the archive index.</p>
+          </div>
+        {% endif %}
+
+        {% if paginationInfo %}
+          <footer class="archive-month__pagination">
+            <p>
+              Showing {{ storiesCount }} of {{ paginationInfo.total_items or entry.count }} archived stories.
+              {% if paginationInfo.total_pages and paginationInfo.total_pages > 1 %}
+                Page 1 of {{ paginationInfo.total_pages }}.
+              {% endif %}
+            </p>
+            {% if paginationInfo.total_pages and paginationInfo.total_pages > 1 %}
+              <p class="archive-month__note">Additional archive pages are available via the JSON feed linked below.</p>
+            {% endif %}
+          </footer>
+        {% endif %}
+      </div>
+
+      <aside class="archive-month__sidebar" aria-label="Archive details">
+        <div class="archive-month__panel">
+          <h2 class="archive-month__panel-title">Archive Details</h2>
+          <dl class="archive-month__stats">
+            <div>
+              <dt>Parent section</dt>
+              <dd>{{ entry.parent | formatArchiveLabel }}</dd>
+            </div>
+            <div>
+              <dt>Subsection</dt>
+              <dd>{{ entry.child | formatArchiveLabel }}</dd>
+            </div>
+            {% if entry.count %}
+            <div>
+              <dt>Stories captured</dt>
+              <dd>{{ entry.count }}</dd>
+            </div>
+            {% endif %}
+            {% if entry.first_date or entry.last_date %}
+            <div>
+              <dt>Date range</dt>
+              <dd>
+                {% if entry.first_date %}
+                  {{ entry.first_date | formatArchiveDate }}
+                {% endif %}
+                {% if entry.last_date and entry.last_date != entry.first_date %}
+                  – {{ entry.last_date | formatArchiveDate }}
+                {% endif %}
+              </dd>
+            </div>
+            {% endif %}
+            {% if entry.updatedAt %}
+            <div>
+              <dt>Last updated</dt>
+              <dd>{{ entry.updatedAt | formatArchiveDate }}</dd>
+            </div>
+            {% endif %}
+            {% if paginationInfo and paginationInfo.total_pages %}
+            <div>
+              <dt>Archive pages</dt>
+              <dd>{{ paginationInfo.total_pages }}</dd>
+            </div>
+            {% endif %}
+          </dl>
+        </div>
+
+        <div class="archive-month__panel">
+          <h2 class="archive-month__panel-title">Data Sources</h2>
+          <ul class="archive-month__links">
+            <li><a href="{{ entry.dataHref }}">Download JSON</a></li>
+            {% if entry.gzipHref %}
+              <li><a href="{{ entry.gzipHref }}">Download JSON (gzip)</a></li>
+            {% endif %}
+            <li><a href="{{ '/data/archive/manifest.json' | url }}">View manifest</a></li>
+          </ul>
+          {% if paginationInfo and paginationInfo.total_pages and paginationInfo.total_pages > 1 %}
+            <p class="archive-month__note">Use the JSON feed to access older pages beyond the first.</p>
+          {% endif %}
+        </div>
+
+        <div class="archive-month__panel">
+          <h2 class="archive-month__panel-title">Navigate</h2>
+          <ul class="archive-month__links">
+            <li><a href="{{ '/archive.html' | url }}">Archive index</a></li>
+            {% if categorySlug %}
+              <li><a href="{{ ('/category.html?cat=' ~ categorySlug) | url }}">View live category</a></li>
+            {% endif %}
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </div>
+</section>

--- a/src/style.scss
+++ b/src/style.scss
@@ -4303,3 +4303,268 @@ blockquote {
   }
 }
 
+.archive-month {
+  $primary: color($colors, primary);
+  $secondary: color($colors, secondary);
+  $ink: color($colors, dark);
+
+  &__header {
+    .archive__title {
+      letter-spacing: 3px;
+    }
+  }
+
+  &__breadcrumbs {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin: 0 0 12px;
+    font-size: 13px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: rgba($ink, .55);
+
+    a {
+      font-weight: 700;
+      color: $primary;
+
+      &:hover,
+      &:focus {
+        color: $secondary;
+      }
+    }
+  }
+
+  &__layout {
+    display: grid;
+    gap: 40px;
+  }
+
+  &__main {
+    display: grid;
+    gap: 28px;
+  }
+
+  &__stories {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 24px;
+  }
+
+  &__story {
+    margin: 0;
+  }
+
+  &__card {
+    background-color: #fff;
+    border-radius: 18px;
+    box-shadow: 0 25px 60px rgba($ink, .08);
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  &__media {
+    background: rgba($ink, .04);
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+  }
+
+  &__content {
+    padding: 24px 30px 30px;
+    display: grid;
+    gap: 14px;
+  }
+
+  &__story-title {
+    margin: 0;
+    font-size: 26px;
+    line-height: 1.3;
+    text-transform: none;
+    letter-spacing: 0;
+
+    a {
+      color: $ink;
+
+      &:hover,
+      &:focus {
+        color: $secondary;
+      }
+    }
+  }
+
+  &__excerpt {
+    margin: 0;
+    font-size: 16px;
+    line-height: 1.7;
+    color: rgba($ink, .75);
+  }
+
+  &__meta {
+    margin: 0;
+    display: grid;
+    gap: 6px;
+    font-size: 14px;
+
+    div {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      align-items: baseline;
+    }
+
+    dt {
+      margin: 0;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 1.6px;
+      color: rgba($ink, .6);
+    }
+
+    dd {
+      margin: 0;
+      color: rgba($ink, .75);
+    }
+
+    a {
+      color: $primary;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1.3px;
+      font-size: 12px;
+
+      &:hover,
+      &:focus {
+        color: $secondary;
+      }
+    }
+  }
+
+  &__empty {
+    background-color: #fff;
+    border-radius: 18px;
+    box-shadow: 0 25px 60px rgba($ink, .08);
+    padding: 40px 32px;
+    text-align: center;
+    font-size: 18px;
+    line-height: 1.7;
+    color: rgba($ink, .68);
+    display: grid;
+    gap: 16px;
+  }
+
+  &__pagination {
+    text-align: center;
+    display: grid;
+    gap: 8px;
+    font-size: 15px;
+    color: rgba($ink, .7);
+
+    p {
+      margin: 0;
+    }
+  }
+
+  &__note {
+    font-size: 14px;
+    color: rgba($ink, .6);
+    line-height: 1.6;
+  }
+
+  &__sidebar {
+    display: grid;
+    gap: 24px;
+  }
+
+  &__panel {
+    background-color: #fff;
+    border-radius: 18px;
+    box-shadow: 0 25px 60px rgba($ink, .08);
+    padding: 28px 30px;
+    display: grid;
+    gap: 18px;
+  }
+
+  &__panel-title {
+    margin: 0;
+    font-size: 18px;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+  }
+
+  &__stats {
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 14px;
+
+    div {
+      display: grid;
+      gap: 4px;
+    }
+
+    dt {
+      margin: 0;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 1.6px;
+      color: rgba($ink, .6);
+    }
+
+    dd {
+      margin: 0;
+      font-size: 16px;
+      color: rgba($ink, .85);
+    }
+  }
+
+  &__links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 10px;
+
+    a {
+      font-size: 13px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1.6px;
+      color: $primary;
+
+      &:hover,
+      &:focus {
+        color: $secondary;
+      }
+    }
+  }
+
+  @media (min-width: 992px) {
+    &__layout {
+      grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+      align-items: start;
+    }
+  }
+
+  @media (max-width: 767px) {
+    &__content {
+      padding: 20px;
+    }
+
+    &__panel {
+      padding: 24px;
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- read the archive manifest and shard data during builds so page generation has the story lists and metadata
- add an Eleventy pagination template that renders monthly archive pages with story cards, metadata, and data source links
- style the archive month layout and register filters to format labels, dates, and URLs used by the new template

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d04b1ed5c083339e3639801d4eec1d