### PR TITLE
Ensure hot shard helpers include index fallbacks

### DIFF
--- a/js/best-of-week.js
+++ b/js/best-of-week.js
@@ -83,12 +83,32 @@
     var normalizedChild = child != null && child !== '' ? slugify(child) : '';
     if (!normalizedChild) normalizedChild = 'index';
     var prefix = HOT_SHARD_ROOT.replace(/\/+$/, '');
-    var path = prefix ? prefix + '/' + normalizedParent + '/' + normalizedChild + '.json' : normalizedParent + '/' + normalizedChild + '.json';
-    var relative = path.replace(/^\/+/, '');
-    return [
-      relative,
-      '/' + relative
+    var basePath = prefix ? prefix + '/' + normalizedParent : normalizedParent;
+    var childIndexSegment = normalizedChild === 'index' ? 'index' : normalizedChild + '/index';
+    var rawCandidates = [
+      basePath + '/' + childIndexSegment + '.json',
+      basePath + '/' + normalizedChild + '.json'
     ];
+    var urls = [];
+    for (var i = 0; i < rawCandidates.length; i++) {
+      var raw = rawCandidates[i];
+      if (!raw) continue;
+      var relative = raw.replace(/^\/+/, '');
+      if (!relative) continue;
+      urls.push(relative);
+      urls.push('/' + relative);
+    }
+    var seen = Object.create(null);
+    var deduped = [];
+    for (var j = 0; j < urls.length; j++) {
+      var candidate = urls[j];
+      if (typeof candidate !== 'string') continue;
+      var trimmed = candidate.trim();
+      if (!trimmed || seen[trimmed]) continue;
+      seen[trimmed] = true;
+      deduped.push(trimmed);
+    }
+    return deduped;
   }
 
   function fetchHotShard(parent, child) {

--- a/js/category.js
+++ b/js/category.js
@@ -440,14 +440,22 @@
     var normalizedChild = child != null && child !== '' ? slugify(child) : '';
     if (!normalizedChild) normalizedChild = 'index';
     var prefix = typeof HOT_SHARD_ROOT === 'string' ? HOT_SHARD_ROOT.replace(/\/+$/, '') : '';
-    var path = prefix
-      ? prefix + '/' + normalizedParent + '/' + normalizedChild + '.json'
-      : normalizedParent + '/' + normalizedChild + '.json';
-    var relative = path.replace(/^\/+/, '');
-    return [
-      relative,
-      '/' + relative
+    var basePath = prefix ? prefix + '/' + normalizedParent : normalizedParent;
+    var childIndexSegment = normalizedChild === 'index' ? 'index' : normalizedChild + '/index';
+    var rawCandidates = [
+      basePath + '/' + childIndexSegment + '.json',
+      basePath + '/' + normalizedChild + '.json'
     ];
+    var urls = [];
+    for (var i = 0; i < rawCandidates.length; i++) {
+      var raw = rawCandidates[i];
+      if (!raw) continue;
+      var relative = raw.replace(/^\/+/, '');
+      if (!relative) continue;
+      urls.push(relative);
+      urls.push('/' + relative);
+    }
+    return uniqueStrings(urls);
   }
 
   function buildArchiveMonthCandidates(parent, child, year, month) {

--- a/js/home-latest.js
+++ b/js/home-latest.js
@@ -144,12 +144,32 @@
     var normalizedChild = child != null && child !== '' ? slugify(child) : '';
     if (!normalizedChild) normalizedChild = 'index';
     var prefix = HOT_SHARD_ROOT.replace(/\/+$/, '');
-    var path = prefix ? prefix + '/' + normalizedParent + '/' + normalizedChild + '.json' : normalizedParent + '/' + normalizedChild + '.json';
-    var relative = path.replace(/^\/+/, '');
-    return [
-      relative,
-      '/' + relative
+    var basePath = prefix ? prefix + '/' + normalizedParent : normalizedParent;
+    var childIndexSegment = normalizedChild === 'index' ? 'index' : normalizedChild + '/index';
+    var rawCandidates = [
+      basePath + '/' + childIndexSegment + '.json',
+      basePath + '/' + normalizedChild + '.json'
     ];
+    var urls = [];
+    for (var i = 0; i < rawCandidates.length; i++) {
+      var raw = rawCandidates[i];
+      if (!raw) continue;
+      var relative = raw.replace(/^\/+/, '');
+      if (!relative) continue;
+      urls.push(relative);
+      urls.push('/' + relative);
+    }
+    var seen = Object.create(null);
+    var deduped = [];
+    for (var j = 0; j < urls.length; j++) {
+      var candidate = urls[j];
+      if (typeof candidate !== 'string') continue;
+      var trimmed = candidate.trim();
+      if (!trimmed || seen[trimmed]) continue;
+      seen[trimmed] = true;
+      deduped.push(trimmed);
+    }
+    return deduped;
   }
 
   function fetchHotShard(parent, child) {

--- a/js/homepage-hot-news.js
+++ b/js/homepage-hot-news.js
@@ -75,12 +75,32 @@
     var normalizedChild = child != null && child !== '' ? slugify(child) : '';
     if (!normalizedChild) normalizedChild = 'index';
     var prefix = HOT_SHARD_ROOT.replace(/\/+$/, '');
-    var path = prefix ? prefix + '/' + normalizedParent + '/' + normalizedChild + '.json' : normalizedParent + '/' + normalizedChild + '.json';
-    var relative = path.replace(/^\/+/, '');
-    return [
-      relative,
-      '/' + relative
+    var basePath = prefix ? prefix + '/' + normalizedParent : normalizedParent;
+    var childIndexSegment = normalizedChild === 'index' ? 'index' : normalizedChild + '/index';
+    var rawCandidates = [
+      basePath + '/' + childIndexSegment + '.json',
+      basePath + '/' + normalizedChild + '.json'
     ];
+    var urls = [];
+    for (var i = 0; i < rawCandidates.length; i++) {
+      var raw = rawCandidates[i];
+      if (!raw) continue;
+      var relative = raw.replace(/^\/+/, '');
+      if (!relative) continue;
+      urls.push(relative);
+      urls.push('/' + relative);
+    }
+    var seen = Object.create(null);
+    var deduped = [];
+    for (var j = 0; j < urls.length; j++) {
+      var candidate = urls[j];
+      if (typeof candidate !== 'string') continue;
+      var trimmed = candidate.trim();
+      if (!trimmed || seen[trimmed]) continue;
+      seen[trimmed] = true;
+      deduped.push(trimmed);
+    }
+    return deduped;
   }
 
   function fetchHotShard(parent, child) {

--- a/js/single.js
+++ b/js/single.js
@@ -192,14 +192,22 @@
     var normalizedChild = child != null && child !== '' ? slugify(child) : '';
     if (!normalizedChild) normalizedChild = 'index';
     var prefix = HOT_SHARD_ROOT.replace(/\/+$/, '');
-    var path = prefix
-      ? prefix + '/' + normalizedParent + '/' + normalizedChild + '.json'
-      : normalizedParent + '/' + normalizedChild + '.json';
-    var relative = path.replace(/^\/+/, '');
-    return [
-      relative,
-      '/' + relative
+    var basePath = prefix ? prefix + '/' + normalizedParent : normalizedParent;
+    var childIndexSegment = normalizedChild === 'index' ? 'index' : normalizedChild + '/index';
+    var rawCandidates = [
+      basePath + '/' + childIndexSegment + '.json',
+      basePath + '/' + normalizedChild + '.json'
     ];
+    var urls = [];
+    for (var i = 0; i < rawCandidates.length; i++) {
+      var raw = rawCandidates[i];
+      if (!raw) continue;
+      var relative = raw.replace(/^\/+/, '');
+      if (!relative) continue;
+      urls.push(relative);
+      urls.push('/' + relative);
+    }
+    return uniqueStrings(urls);
   }
 
   function fetchHotShard(parent, child) {


### PR DESCRIPTION
## Summary
- generate both `<parent>/<child>/index.json` and `<parent>/<child>.json` candidates across the hot shard helpers
- order the index candidate first and dedupe the resulting list (using `uniqueStrings` where available) so requests resolve without redundant lookups

## Testing
- npm run build
- curl -I http://127.0.0.1:8080/data/hot/news/top-stories/index.json

------
https://chatgpt.com/codex/tasks/task_e_68d054ec367c83338a77398bd9dbcc34