### PR TITLE
Fix hot shard URL candidates for index variants

### DIFF
--- a/js/category.js
+++ b/js/category.js
@@ -440,14 +440,22 @@
     var normalizedChild = child != null && child !== '' ? slugify(child) : '';
     if (!normalizedChild) normalizedChild = 'index';
     var prefix = typeof HOT_SHARD_ROOT === 'string' ? HOT_SHARD_ROOT.replace(/\/+$/, '') : '';
-    var path = prefix
-      ? prefix + '/' + normalizedParent + '/' + normalizedChild + '.json'
-      : normalizedParent + '/' + normalizedChild + '.json';
-    var relative = path.replace(/^\/+/, '');
-    return [
-      relative,
-      '/' + relative
+    var segments = [normalizedParent];
+    if (normalizedChild) {
+      segments.push(normalizedChild);
+    }
+    var joined = segments.join('/');
+    var basePath = prefix ? prefix + '/' + joined : joined;
+    var relative = basePath.replace(/^\//, '');
+    var candidates = [
+      basePath + '.json',
+      relative + '.json'
     ];
+    if (normalizedChild !== 'index') {
+      candidates.push(basePath + '/index.json');
+      candidates.push(relative + '/index.json');
+    }
+    return uniqueStrings(candidates);
   }
 
   function buildArchiveMonthCandidates(parent, child, year, month) {

--- a/js/single.js
+++ b/js/single.js
@@ -192,14 +192,22 @@
     var normalizedChild = child != null && child !== '' ? slugify(child) : '';
     if (!normalizedChild) normalizedChild = 'index';
     var prefix = HOT_SHARD_ROOT.replace(/\/+$/, '');
-    var path = prefix
-      ? prefix + '/' + normalizedParent + '/' + normalizedChild + '.json'
-      : normalizedParent + '/' + normalizedChild + '.json';
-    var relative = path.replace(/^\/+/, '');
-    return [
-      relative,
-      '/' + relative
+    var segments = [normalizedParent];
+    if (normalizedChild) {
+      segments.push(normalizedChild);
+    }
+    var joined = segments.join('/');
+    var basePath = prefix ? prefix + '/' + joined : joined;
+    var relative = basePath.replace(/^\//, '');
+    var candidates = [
+      basePath + '.json',
+      relative + '.json'
     ];
+    if (normalizedChild !== 'index') {
+      candidates.push(basePath + '/index.json');
+      candidates.push(relative + '/index.json');
+    }
+    return uniqueStrings(candidates);
   }
 
   function fetchHotShard(parent, child) {


### PR DESCRIPTION
## Summary
- include `/index.json` fallbacks when building hot shard URL lists for article view
- apply the same shard candidate logic to category view fetching

## Testing
- npx @11ty/eleventy --serve

------
https://chatgpt.com/codex/tasks/task_e_68d0550a208c83339799d48434fd77cf