### PR TITLE
Enable caching in data loader sequential fetch

### DIFF
--- a/js/best-of-week.js
+++ b/js/best-of-week.js
@@ -18,11 +18,11 @@
   var DEFAULT_SCOPE = { parent: 'index', child: 'index' };
   var HOT_POSTS_CACHE = Object.create(null);
 
-  function fetchSequential(urls) {
+  function fetchSequential(urls, options) {
     if (!window.AventurOODataLoader || typeof window.AventurOODataLoader.fetchSequential !== 'function') {
       return Promise.reject(new Error('Data loader is not available'));
     }
-    return window.AventurOODataLoader.fetchSequential(urls);
+    return window.AventurOODataLoader.fetchSequential(urls, options);
   }
 
   function normalizePostsPayload(payload) {

--- a/js/category.js
+++ b/js/category.js
@@ -36,11 +36,11 @@
 
 
 
-  function fetchSequential(urls) {
+  function fetchSequential(urls, options) {
     if (!window.AventurOODataLoader || typeof window.AventurOODataLoader.fetchSequential !== 'function') {
       return Promise.reject(new Error('Data loader is not available'));
     }
-    return window.AventurOODataLoader.fetchSequential(urls);
+    return window.AventurOODataLoader.fetchSequential(urls, options);
   }
 
   function slugify(s) {

--- a/js/data-loader.js
+++ b/js/data-loader.js
@@ -48,7 +48,7 @@
       return Promise.reject(new Error('No matching resource found'));
     }
 
-    var settings = Object.assign({ cache: 'no-store' }, options || {});
+    var settings = Object.assign({ cache: 'default' }, options || {});
 
     return new Promise(function (resolve, reject) {
       var index = 0;

--- a/js/home-latest.js
+++ b/js/home-latest.js
@@ -20,11 +20,11 @@
   var HOT_SHARD_ROOT = '/data/hot';
   var DEFAULT_SCOPE = { parent: 'index', child: 'index' };
 
-  function fetchSequential(urls) {
+  function fetchSequential(urls, options) {
     if (!window.AventurOODataLoader || typeof window.AventurOODataLoader.fetchSequential !== 'function') {
       return Promise.reject(new Error('Data loader is not available'));
     }
-    return window.AventurOODataLoader.fetchSequential(urls);
+    return window.AventurOODataLoader.fetchSequential(urls, options);
   }
 
   function loadJson(urls) {

--- a/js/homepage-hot-news.js
+++ b/js/homepage-hot-news.js
@@ -22,11 +22,11 @@
   var DEFAULT_SCOPE = { parent: 'index', child: 'index' };
   var HOT_POSTS_CACHE = Object.create(null);
 
-  function fetchSequential(urls) {
+  function fetchSequential(urls, options) {
     if (!window.AventurOODataLoader || typeof window.AventurOODataLoader.fetchSequential !== 'function') {
       return Promise.reject(new Error('Data loader is not available'));
     }
-    return window.AventurOODataLoader.fetchSequential(urls);
+    return window.AventurOODataLoader.fetchSequential(urls, options);
   }
 
   function normalizePostsPayload(payload) {

--- a/js/search.js
+++ b/js/search.js
@@ -19,11 +19,11 @@
   var MONTH_CACHE = Object.create(null);
   var ARCHIVE_SUMMARY_PROMISE = null;
 
-  function fetchSequential(urls) {
+  function fetchSequential(urls, options) {
     if (!window.AventurOODataLoader || typeof window.AventurOODataLoader.fetchSequential !== 'function') {
       return Promise.reject(new Error('Data loader is not available'));
     }
-    return window.AventurOODataLoader.fetchSequential(urls);
+    return window.AventurOODataLoader.fetchSequential(urls, options);
   }
 
   function slugify(value) {

--- a/js/single.js
+++ b/js/single.js
@@ -50,11 +50,11 @@
 
   var headElement = document.head || document.getElementsByTagName('head')[0] || null;
 
-  function fetchSequential(urls) {
+  function fetchSequential(urls, options) {
     if (!window.AventurOODataLoader || typeof window.AventurOODataLoader.fetchSequential !== 'function') {
       return Promise.reject(new Error('Data loader is not available'));
     }
-    return window.AventurOODataLoader.fetchSequential(urls);
+    return window.AventurOODataLoader.fetchSequential(urls, options);
   }
 
   function slugify(value) {


### PR DESCRIPTION
## Summary
- default the shared data loader to use the browser cache instead of `no-store`
- let modules that call the loader forward custom fetch options when cache-busting is required

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d11d0613308333b55c93c5cb4e9053