### PR TITLE
Add lightweight headline index and update carousel sources

### DIFF
--- a/data/headline.json
+++ b/data/headline.json
@@ -1,0 +1,142 @@
+[
+  {
+    "slug": "ustoa-update-meet-the-future-leaders-of-the-responsible-travel-movement-2025-09-22",
+    "title": "USTOA Update: Meet the Future Leaders of the Responsible Travel Movement",
+    "cover": "https://ik.imgkit.net/3vlqs5axxjf/TP/ik-seo/images/99999999-9999-9999-9999-999999999999/7489c2f3-5ac1-4564-a7d7-818579df7f84/source/USTOA-Update-Meet-the-Future-Leaders-of-the-Respon.png?tr=w-1366%2Ch-768%2Cfo-auto",
+    "category": "Travel",
+    "date": "2025-09-22"
+  },
+  {
+    "slug": "destination-wedding-and-honeymoon-trends-for-2025-and-beyond-2025-09-22",
+    "title": "Destination Wedding and Honeymoon Trends for 2025 and Beyond",
+    "cover": "https://ik.imgkit.net/3vlqs5axxjf/TP/ik-seo/images/99999999-9999-9999-9999-999999999999/cfc8b716-a1d2-4ab2-950f-fc8ef49270e0/source/Destination-Wedding-and-Honeymoon-Trends-for-2025-.jpeg?tr=w-1366%2Ch-768%2Cfo-auto",
+    "category": "Travel",
+    "date": "2025-09-22"
+  },
+  {
+    "slug": "amex-platinum-vs-business-platinum-which-premium-amex-card-is-right-for-you-2025-09-21",
+    "title": "Amex Platinum vs. Business Platinum: Which premium Amex card is right for you?",
+    "cover": "https://runway-media-production.global.ssl.fastly.net/us/originals/2023/08/Person-handing-credit-card-over-to-make-payment-at-restaurant_LightFieldStudios.jpg",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "how-i-earned-2-million-amex-membership-rewards-points-2025-09-21",
+    "title": "How I Earned 2 Million Amex Membership Rewards Points",
+    "cover": "https://upgradedpoints.com/wp-content/uploads/2018/02/Amex-Gold-Platinum-Blue-Business-Plus-Cards-Upgraded-Points-LLC.png",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "americans-will-now-need-an-entry-permit-to-visit-this-popular-safari-country-2025-09-21",
+    "title": "Americans Will Now Need An Entry Permit To Visit This Popular Safari Country",
+    "cover": "https://www.traveloffpath.com/wp-content/uploads/2025/09/Pilanesberg-South-Africa-Lush-private-game-lodge-for-exciting-safaris.jpg",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "the-best-hotel-bonus-points-promotions-september-2025-2025-09-21",
+    "title": "The best hotel bonus points promotions – September 2025",
+    "cover": "https://boardingarea.com/wp-content/uploads/2025/09/fc56975b52d65e21fba8756ae6545e46.png",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "amex-platinum-changes-live-earn-southwest-companion-pass-with-one-credit-card-and-more-2025-09-21",
+    "title": "Amex Platinum Changes Live, Earn Southwest Companion Pass with One Credit Card, and More",
+    "cover": "https://boardingarea.com/wp-content/uploads/2025/09/7dab455db20f09cca781961797e04be4.jpg",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "report-h1b-visa-executive-order-causes-sfo-flight-delays-2025-09-21",
+    "title": "Report: H1B Visa Executive Order Causes SFO Flight Delays",
+    "cover": "https://boardingarea.com/wp-content/uploads/2025/09/76947bd4b9b73bdcd8f85767db474490.jpg",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "american-airlines-ordered-to-pay-13-2-million-to-passenger-who-suffered-stroke-mid-flight-because-crew-didn-t-follow-medical-procedures-2025-09-21",
+    "title": "American Airlines Ordered to Pay $13.2 Million To Passenger Who Suffered Stroke Mid-Flight Because Crew Didn’t Follow Medical Procedures",
+    "cover": "https://boardingarea.com/wp-content/uploads/2025/09/8f2894a6defc636f34d65e4ffc3da2e9.jpg",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "lufthansa-s-festive-oktoberfest-flights-return-for-2025-what-to-expect-2025-09-21",
+    "title": "Lufthansa’s Festive Oktoberfest Flights Return For 2025: What To Expect",
+    "cover": "https://boardingarea.com/wp-content/uploads/2025/09/529f6f8f49392f1e3f64e307e6f99168.jpeg",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "up-to-110-daily-flights-the-us-canada-s-10-busiest-airports-for-european-flights-in-october-2025-09-21",
+    "title": "Up To 110 Daily Flights: The US & Canada's 10 Busiest Airports For European Flights In October",
+    "cover": "https://static0.simpleflyingimages.com/wordpress/wp-content/uploads/2025/09/united-airlines-boeing-787-8-taxiing-1.jpg",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "nearly-100-full-exploring-cathay-pacific-s-brand-new-dallas-flights-2025-09-21",
+    "title": "Nearly 100% Full: Exploring Cathay Pacific's Brand-New Dallas Flights",
+    "cover": "https://static0.simpleflyingimages.com/wordpress/wp-content/uploads/2025/09/shutterstock_1835755075-1.jpg",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "why-did-lockheed-martin-build-the-c-5-galaxy-with-a-t-tail-2025-09-21",
+    "title": "Why Did Lockheed Martin Build The C-5 Galaxy With A T-Tail?",
+    "cover": "https://static0.simpleflyingimages.com/wordpress/wp-content/uploads/2025/09/galaxy.jpg",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "these-are-the-busiest-boeing-777-300er-flights-in-october-2025-09-21",
+    "title": "These Are The Busiest Boeing 777-300ER Flights In October",
+    "cover": "https://static0.simpleflyingimages.com/wordpress/wp-content/uploads/2025/09/adobe-express-file-2025-09-19t224632-583.jpg",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "up-to-16h-40m-cathay-pacific-s-10-longest-flights-examined-2025-09-21",
+    "title": "Up To 16h 40m: Cathay Pacific's 10 Longest Flights Examined",
+    "cover": "https://static0.simpleflyingimages.com/wordpress/wp-content/uploads/2025/09/cathay-pacific-airbus-a350-1000-taxiing-to-its-stand.jpg",
+    "category": "Travel",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "our-favorite-slim-magsafe-power-bank-is-down-to-a-new-low-price-2025-09-21",
+    "title": "Our favorite slim MagSafe power bank is down to a new low price",
+    "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2025-09%2Fe99eece0-92e8-11f0-adfb-69cdd9456876&resize=1400%2C787&client=19f2b5e49a271b2bde77&signature=1d99044bfeb0a9df260d7e8fe72c44c3d73e3dd4",
+    "category": "Tech & AI",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "early-prime-day-deal-8bitdo-s-pro-2-controller-with-travel-case-drops-to-40-2025-09-21",
+    "title": "Early Prime Day deal: 8Bitdo's Pro 2 controller with travel case drops to $40",
+    "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2021-04%2Fc2b3f360-92d3-11eb-b73a-ae82bfa05d04&resize=1400%2C787&client=19f2b5e49a271b2bde77&signature=2450681828e08b644201f1a6002bb52c1232a83f",
+    "category": "Tech & AI",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "this-samsung-evo-microsd-card-is-on-sale-for-only-20-2025-09-21",
+    "title": "This Samsung EVO microSD card is on sale for only $20",
+    "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2024-10%2Fedb15e20-8b0b-11ef-a12f-0a06726344cf&resize=1400%2C788&client=19f2b5e49a271b2bde77&signature=24de35e9b1d4a49045d97299ef24f0425fabc093",
+    "category": "Tech & AI",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "i-m-a-smart-home-tech-editor-and-these-are-the-best-3-video-doorbells-with-chimes-you-can-buy-today-2025-09-21",
+    "title": "I'm a smart home tech editor, and these are the best 3 video doorbells with chimes you can buy today",
+    "cover": "https://cdn.mos.cms.futurecdn.net/UsMUQLiRa8vKTbwkXpPdSY-1280-80.jpg",
+    "category": "Tech & AI",
+    "date": "2025-09-21"
+  },
+  {
+    "slug": "the-gopro-max-2-is-coming-next-week-with-another-mystery-camera-and-we-ve-seen-a-ton-of-leaks-2025-09-21",
+    "title": "The GoPro Max 2 is coming next week, with another mystery camera – and we've seen a ton of leaks",
+    "cover": "https://cdn.mos.cms.futurecdn.net/iZ59HPN3RUjf5Xe7ggwQa9-1280-80.jpg",
+    "category": "Tech & AI",
+    "date": "2025-09-21"
+  }
+]

--- a/js/e-magz.js
+++ b/js/e-magz.js
@@ -6,7 +6,9 @@ $(function(){
         };
 
         var youtube_api_key = 'YOUR_API_KEY';
-        var HEADLINE_POSTS_SOURCES = basePath.resolveAll ? basePath.resolveAll(['data/posts.json', '/data/posts.json']) : ['data/posts.json', '/data/posts.json'];
+        var HEADLINE_POSTS_SOURCES = basePath.resolveAll
+                ? basePath.resolveAll(['data/headline.json', '/data/headline.json', 'data/posts.json', '/data/posts.json'])
+                : ['data/headline.json', '/data/headline.json', 'data/posts.json', '/data/posts.json'];
         var HEADLINE_MAX_ITEMS = 20;
 
         function fetchSequential(urls) {

--- a/tests/test_pull_news.py
+++ b/tests/test_pull_news.py
@@ -38,6 +38,7 @@ class FeedUrlParsingTests(unittest.TestCase):
         original_posts_json = pull_news.POSTS_JSON
         original_seen_db = pull_news.SEEN_DB
         original_data_dir = pull_news.DATA_DIR
+        original_headline_json = pull_news.HEADLINE_JSON
 
         try:
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -52,6 +53,7 @@ class FeedUrlParsingTests(unittest.TestCase):
                 pull_news.DATA_DIR = tmp_path
                 pull_news.POSTS_JSON = tmp_path / "posts.json"
                 pull_news.SEEN_DB = tmp_path / "seen.json"
+                pull_news.HEADLINE_JSON = tmp_path / "headline.json"
 
                 fetched_urls = []
 
@@ -79,6 +81,7 @@ class FeedUrlParsingTests(unittest.TestCase):
             pull_news.POSTS_JSON = original_posts_json
             pull_news.SEEN_DB = original_seen_db
             pull_news.DATA_DIR = original_data_dir
+            pull_news.HEADLINE_JSON = original_headline_json
 
 
 class CategoryFilterNormalizationTests(unittest.TestCase):
@@ -97,6 +100,7 @@ class CategoryFilterNormalizationTests(unittest.TestCase):
         original_seen_db = pull_news.SEEN_DB
         original_data_dir = pull_news.DATA_DIR
         original_category = pull_news.CATEGORY
+        original_headline_json = pull_news.HEADLINE_JSON
 
         try:
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -109,6 +113,7 @@ class CategoryFilterNormalizationTests(unittest.TestCase):
                 pull_news.POSTS_JSON = tmp_path / "posts.json"
                 pull_news.SEEN_DB = tmp_path / "seen.json"
                 pull_news.CATEGORY = "CRYPTO"
+                pull_news.HEADLINE_JSON = tmp_path / "headline.json"
 
                 patchers = [
                     mock.patch.object(pull_news, "fetch_bytes", return_value=b"<xml>"),
@@ -140,6 +145,7 @@ class CategoryFilterNormalizationTests(unittest.TestCase):
             pull_news.SEEN_DB = original_seen_db
             pull_news.DATA_DIR = original_data_dir
             pull_news.CATEGORY = original_category
+            pull_news.HEADLINE_JSON = original_headline_json
 
 
 class MaxPerFeedLimitTests(unittest.TestCase):
@@ -156,6 +162,7 @@ class MaxPerFeedLimitTests(unittest.TestCase):
         original_max_per_feed = pull_news.MAX_PER_FEED
         original_hot_max_items = pull_news.HOT_MAX_ITEMS
         original_hot_page_size = pull_news.HOT_PAGE_SIZE
+        original_headline_json = pull_news.HEADLINE_JSON
 
         try:
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -170,6 +177,7 @@ class MaxPerFeedLimitTests(unittest.TestCase):
                 pull_news.MAX_PER_FEED = 2
                 pull_news.HOT_MAX_ITEMS = 10
                 pull_news.HOT_PAGE_SIZE = 5
+                pull_news.HEADLINE_JSON = tmp_path / "headline.json"
 
                 patchers = [
                     mock.patch.object(pull_news, "fetch_bytes", return_value=b"<xml>"),
@@ -201,6 +209,20 @@ class MaxPerFeedLimitTests(unittest.TestCase):
                     "per_page": 5,
                     "total_pages": 1,
                 })
+
+                headline_path = tmp_path / "headline.json"
+                self.assertTrue(headline_path.exists())
+                headline_payload = json.loads(headline_path.read_text(encoding="utf-8"))
+                self.assertEqual(len(headline_payload), 2)
+                self.assertEqual(
+                    [item["slug"] for item in headline_payload],
+                    [item["slug"] for item in data[:2]],
+                )
+                for entry in headline_payload:
+                    self.assertEqual(
+                        ["category", "cover", "date", "slug", "title"],
+                        sorted(entry.keys()),
+                    )
         finally:
             pull_news.FEEDS = original_feeds
             pull_news.POSTS_JSON = original_posts_json
@@ -209,6 +231,7 @@ class MaxPerFeedLimitTests(unittest.TestCase):
             pull_news.MAX_PER_FEED = original_max_per_feed
             pull_news.HOT_MAX_ITEMS = original_hot_max_items
             pull_news.HOT_PAGE_SIZE = original_hot_page_size
+            pull_news.HEADLINE_JSON = original_headline_json
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend the autopost pipeline to emit a lightweight `headline.json` alongside `posts.json`
- ship the generated `data/headline.json` snapshot for the latest 20 posts
- prefer the new headline dataset in the e-magz carousel and cover the behavior in tests

## Testing
- python -m pytest tests/test_pull_news.py

------
https://chatgpt.com/codex/tasks/task_e_68d13ac59ea88333ab4acc730b54811f