### PR TITLE
Adjust data loader caching defaults

### DIFF
--- a/js/data-loader.js
+++ b/js/data-loader.js
@@ -2,6 +2,7 @@
   'use strict';
 
   var fetch = global.fetch;
+  var DEFAULT_FETCH_OPTIONS = { cache: 'default' };
 
   function applyBasePath(url) {
     if (!url) return '';
@@ -38,6 +39,14 @@
     return contentType.toLowerCase().indexOf('json') !== -1;
   }
 
+  function buildFetchSettings(overrides) {
+    var base = Object.assign({}, DEFAULT_FETCH_OPTIONS);
+    if (!overrides || typeof overrides !== 'object') {
+      return base;
+    }
+    return Object.assign(base, overrides);
+  }
+
   function fetchSequential(urls, options) {
     if (typeof fetch !== 'function') {
       return Promise.reject(new Error('Fetch API is not available'));
@@ -48,7 +57,7 @@
       return Promise.reject(new Error('No matching resource found'));
     }
 
-    var settings = Object.assign({ cache: 'default' }, options || {});
+    var settings = buildFetchSettings(options);
 
     return new Promise(function (resolve, reject) {
       var index = 0;

--- a/js/single.js
+++ b/js/single.js
@@ -1053,7 +1053,7 @@
   function loadLegacyPost(slugValue) {
     var normalized = slugify(slugValue);
     if (!normalized) return Promise.resolve(null);
-    return fetchSequential(LEGACY_LOOKUP_SOURCES)
+    return fetchSequential(LEGACY_LOOKUP_SOURCES, { cache: 'no-store' })
       .then(function (payload) {
         var lookup = normalizeLegacyLookupPayload(payload);
         var entry = lookup[normalized];


### PR DESCRIPTION
## Summary
- add a reusable default fetch settings helper so AventurOO data loader opts into browser caching by default
- keep support for per-call overrides while defaulting to cached requests for hot/manifest/archive data
- force the legacy lookup fetch on article pages to bypass the cache so new archive entries appear immediately

## Testing
- npm run build
- PYTHONPATH=. pytest


------
https://chatgpt.com/codex/tasks/task_e_68d13abc67a0833381195f6279e5d6e4