### PR TITLE
Add slugify helper to homepage hot news module

### DIFF
--- a/js/homepage-hot-news.js
+++ b/js/homepage-hot-news.js
@@ -29,6 +29,17 @@
     return window.AventurOODataLoader.fetchSequential(urls, options);
   }
 
+  function slugify(value) {
+    return (value || '')
+      .toString()
+      .trim()
+      .toLowerCase()
+      .replace(/\.html?$/i, '')
+      .replace(/&/g, 'and')
+      .replace(/[_\W]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
   function normalizePostsPayload(payload) {
     if (!payload) return [];
     if (Array.isArray(payload)) return payload.slice();


### PR DESCRIPTION
## Summary
- add a local slugify helper in `js/homepage-hot-news.js`
- normalize string handling to match other modules using slugify

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d15f369c548333a9f4b841e42128d5