### PR TITLE
Ensure hot news slider defaults to news top stories

### DIFF
--- a/js/homepage-hot-news.js
+++ b/js/homepage-hot-news.js
@@ -19,7 +19,7 @@
   var DEFAULT_CATEGORY_LABEL = 'Top Stories';
   var DEFAULT_IMAGE = basePath.resolve ? basePath.resolve('/images/logo.png') : '/images/logo.png';
   var HOT_SHARD_ROOT = '/data/hot';
-  var DEFAULT_SCOPE = { parent: 'index', child: 'index' };
+  var DEFAULT_SCOPE = { parent: 'news', child: 'top-stories' };
   var HOT_POSTS_CACHE = Object.create(null);
 
   function fetchSequential(urls, options) {

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -119,7 +119,7 @@ featuredFallbackSlugs:
                                                                 </div>
                                                         </div>
                                                 </h1>
-                                                <div id="hot-news-slider" class="body-col vertical-slider" data-max="4" data-nav="#hot-news-nav" data-item="article"></div>
+                                                <div id="hot-news-slider" class="body-col vertical-slider" data-max="4" data-nav="#hot-news-nav" data-item="article" data-hot-parent="news" data-hot-child="top-stories"></div>
                                         </div>
                                 </div>
                                 <div class="line top">


### PR DESCRIPTION
## Summary
- point the hot news loader default scope at the news/top-stories shard so the fetch resolves
- add explicit hot news parent/child data attributes on the homepage slider markup for clarity

## Testing
- if [ -f data/hot/news/top-stories/index.json ]; then echo "hot scope available"; else echo "missing hot scope"; fi


------
https://chatgpt.com/codex/tasks/task_e_68d160419ec083339906c61db58ac1e1