### PR TITLE
Preserve origin port in health worker host header

### DIFF
--- a/scripts/monitoring/cloudflare-health-worker.js
+++ b/scripts/monitoring/cloudflare-health-worker.js
@@ -80,7 +80,8 @@ async function fetchFromOrigin(request, env) {
   };
 
   if (env.HEALTH_ORIGIN) {
-    init.headers.set("host", originUrl.hostname);
+    const hostHeader = originUrl.host || originUrl.hostname;
+    init.headers.set("host", hostHeader);
   }
 
   if (request.method !== "GET" && request.method !== "HEAD") {


### PR DESCRIPTION
## Summary
- forward the original host header using the URL host so configured ports are retained

## Testing
- node - <<'NODE'
const fs = require('fs');
const vm = require('vm');

let code = fs.readFileSync('./scripts/monitoring/cloudflare-health-worker.js', 'utf8');
code = code.replace(/export default[\\s\\S]*/, '');

const sandbox = {
  console,
  fetch: (...args) => {
    console.log('fetch called', args);
    return Promise.resolve(new Response(null));
  },
  Headers,
  Request,
  Response,
  URL,
  URLSearchParams,
  TextDecoder,
  TextEncoder,
  atob,
  btoa,
  setTimeout,
  clearTimeout,
  setInterval,
  clearInterval,
};

vm.createContext(sandbox);
vm.runInContext(code, sandbox);

const request = new Request('https://aventuroo.com/_health/autopost.json');
const env = { HEALTH_ORIGIN: 'https://example.internal:8443' };

sandbox.fetch = (req, init) => {
  console.log('Host header forwarded:', req.headers.get('host'));
  return Promise.resolve(new Response(null));
};

sandbox.fetchFromOrigin(request, env).then(() => process.exit(0));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d16511b78c833398e9c20a2f99782f