### PR TITLE
Add global hot shard and adjust rotation metadata

### DIFF
--- a/tests/test_pull_news.py
+++ b/tests/test_pull_news.py
@@ -332,6 +332,21 @@ class MaxPerFeedLimitTests(unittest.TestCase):
                     "total_pages": 1,
                 })
 
+                root_path = tmp_path / "hot" / "index" / "index.json"
+                self.assertTrue(root_path.exists())
+                root_payload = json.loads(root_path.read_text(encoding="utf-8"))
+                self.assertEqual(root_payload["count"], 2)
+                self.assertEqual(len(root_payload["items"]), 2)
+                self.assertEqual(
+                    sorted(item["slug"] for item in root_payload["items"]),
+                    sorted(item["slug"] for item in data[:2]),
+                )
+                self.assertEqual(root_payload["pagination"], {
+                    "total_items": 2,
+                    "per_page": 5,
+                    "total_pages": 1,
+                })
+
                 headline_path = tmp_path / "headline.json"
                 self.assertTrue(headline_path.exists())
                 headline_payload = json.loads(headline_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- ensure each autopost ingestion also writes a global hot shard under hot/index/index.json
- keep rotation metadata accurate by skipping the global shard in totals and marking it for consumers
- extend tests to cover the new shard and manifest handling

## Testing
- PYTHONPATH=. pytest
- FEEDS_FILE=/tmp/autopost-test/feeds.txt python autopost/pull_news.py
- python scripts/rotate_hot_to_archive.py --retention-days 45 --per-page 12
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1821221288333b50f092333934f5b