### PR TITLE
Avoid hot shard root index requests

### DIFF
--- a/js/best-of-week.js
+++ b/js/best-of-week.js
@@ -78,16 +78,24 @@
     return list;
   }
 
-  function buildShardUrls(parent, child) {
+  function normalizeScope(parent, child) {
     var normalizedParent = slugify(parent) || 'index';
     var normalizedChild = child != null && child !== '' ? slugify(child) : '';
     if (!normalizedChild) normalizedChild = 'index';
+    return { parent: normalizedParent, child: normalizedChild };
+  }
+
+  function buildShardUrls(parent, child) {
+    var scope = normalizeScope(parent, child);
+    if (scope.parent === 'index' && scope.child === 'index') {
+      return [];
+    }
     var prefix = HOT_SHARD_ROOT.replace(/\/+$/, '');
-    var basePath = prefix ? prefix + '/' + normalizedParent : normalizedParent;
-    var childIndexSegment = normalizedChild === 'index' ? 'index' : normalizedChild + '/index';
+    var basePath = prefix ? prefix + '/' + scope.parent : scope.parent;
+    var childIndexSegment = scope.child === 'index' ? 'index' : scope.child + '/index';
     var rawCandidates = [
       basePath + '/' + childIndexSegment + '.json',
-      basePath + '/' + normalizedChild + '.json'
+      basePath + '/' + scope.child + '.json'
     ];
     var urls = [];
     for (var i = 0; i < rawCandidates.length; i++) {
@@ -112,11 +120,15 @@
   }
 
   function fetchHotShard(parent, child) {
-    var scopeKey = (parent || 'index') + '::' + (child || 'index');
+    var scope = normalizeScope(parent, child);
+    if (scope.parent === 'index' && scope.child === 'index') {
+      return Promise.reject(new Error('Root hot shard is not available'));
+    }
+    var scopeKey = scope.parent + '::' + scope.child;
     if (HOT_POSTS_CACHE[scopeKey]) {
       return HOT_POSTS_CACHE[scopeKey];
     }
-    var candidates = buildShardUrls(parent, child);
+    var candidates = buildShardUrls(scope.parent, scope.child);
     HOT_POSTS_CACHE[scopeKey] = fetchSequential(candidates)
       .then(function (payload) {
         return dedupePosts(sortPosts(normalizePostsPayload(payload)));

--- a/js/category.js
+++ b/js/category.js
@@ -515,16 +515,24 @@
     return str;
   }
 
-  function buildHotShardUrls(parent, child) {
+  function normalizeScope(parent, child) {
     var normalizedParent = slugify(parent) || 'index';
     var normalizedChild = child != null && child !== '' ? slugify(child) : '';
     if (!normalizedChild) normalizedChild = 'index';
+    return { parent: normalizedParent, child: normalizedChild };
+  }
+
+  function buildHotShardUrls(parent, child) {
+    var scope = normalizeScope(parent, child);
+    if (scope.parent === 'index' && scope.child === 'index') {
+      return [];
+    }
     var prefix = typeof HOT_SHARD_ROOT === 'string' ? HOT_SHARD_ROOT.replace(/\/+$/, '') : '';
-    var basePath = prefix ? prefix + '/' + normalizedParent : normalizedParent;
-    var childIndexSegment = normalizedChild === 'index' ? 'index' : normalizedChild + '/index';
+    var basePath = prefix ? prefix + '/' + scope.parent : scope.parent;
+    var childIndexSegment = scope.child === 'index' ? 'index' : scope.child + '/index';
     var rawCandidates = [
       basePath + '/' + childIndexSegment + '.json',
-      basePath + '/' + normalizedChild + '.json'
+      basePath + '/' + scope.child + '.json'
     ];
     var urls = [];
     for (var i = 0; i < rawCandidates.length; i++) {
@@ -565,11 +573,15 @@
   }
 
   function fetchHotShard(parent, child) {
-    var scopeKey = (parent || 'index') + '::' + (child || 'index');
+    var scope = normalizeScope(parent, child);
+    if (scope.parent === 'index' && scope.child === 'index') {
+      return Promise.reject(new Error('Root hot shard is not available'));
+    }
+    var scopeKey = scope.parent + '::' + scope.child;
     if (HOT_SHARD_CACHE[scopeKey]) {
       return HOT_SHARD_CACHE[scopeKey];
     }
-    var candidates = buildHotShardUrls(parent, child);
+    var candidates = buildHotShardUrls(scope.parent, scope.child);
     HOT_SHARD_CACHE[scopeKey] = fetchSequential(candidates)
       .then(function (payload) {
         return sortPosts(normalizePostsPayload(payload));


### PR DESCRIPTION
## Summary
- add a shared normalizeScope helper in each homepage hot shard loader to skip the empty index/index shard
- short-circuit fetchHotShard so index/index immediately falls back to legacy data without requesting `/data/hot/index/index.json`
- apply the guard to other widgets that use the default index scope to prevent duplicate 404s

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b7a2bbc88333af712331e7b5b80a