### PR TITLE
Add robots.txt template for Eleventy build

### DIFF
--- a/src/site/robots.njk
+++ b/src/site/robots.njk
@@ -1,0 +1,8 @@
+---
+permalink: "robots.txt"
+eleventyExcludeFromCollections: true
+---
+User-agent: *
+Allow: /
+
+Sitemap: {{ site.url }}/sitemap.xml


### PR DESCRIPTION
## Summary
- add an Eleventy template that emits robots.txt at the site root
- include default crawl rules and sitemap reference using site metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1c249b0c083339c2ee38f0f8dc831