### PR TITLE
Add HTTP-to-HTTPS redirects for Aventuroo domains

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,24 @@
   command = "npm run build"
   publish = "_site"
 
+[[redirects]]
+  from = "http://archive.aventuroo.com/*"
+  to = "https://archive.aventuroo.com/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "http://www.archive.aventuroo.com/*"
+  to = "https://archive.aventuroo.com/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "http://:subdomain.netlify.app/*"
+  to = "https://:subdomain.netlify.app/:splat"
+  status = 301
+  force = true
+
 [[headers]]
   for = "/archive/*"
   [headers.values]


### PR DESCRIPTION
## Summary
- add Netlify redirect rules to enforce HTTPS for archive.aventuroo.com and its www variant
- add redirect rule to upgrade Netlify subdomain traffic to HTTPS

## Testing
- not run (configuration only)

------
https://chatgpt.com/codex/tasks/task_e_68d1caec5cd083339a3548e98598b469