### PR TITLE
Improve contrast for search and not-found text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -687,7 +687,7 @@ section.not-found h1 {
 }
 section.not-found p.lead {
   font-size: 16px;
-  color: #999;
+  color: #555;
 }
 section.not-found .search-form {
   display: inline-block;
@@ -703,7 +703,7 @@ section.not-found .link {
 section.search .search-result {
   margin-top: 10px;
   margin-bottom: 30px;
-  color: #999;
+  color: #555;
 }
 
 .form-control {

--- a/src/style.scss
+++ b/src/style.scss
@@ -508,7 +508,7 @@ section {
     }
     p.lead {
       font-size: 16px;
-      color: #999;
+      color: #555;
     }
     .search-form {
       display: inline-block;
@@ -526,7 +526,7 @@ section {
     .search-result {
       margin-top: 10px;
       margin-bottom: 30px;
-      color: #999;
+      color: #555;
     }
   }
 }


### PR DESCRIPTION
## Summary
- darken the not-found lead text and search result snippets to meet WCAG AA contrast
- refresh the compiled stylesheet so production assets use the new neutral tone

## Testing
- npm run build
- python - <<'PY' ... (contrast ratio check)


------
https://chatgpt.com/codex/tasks/task_e_68d1de7b37488333b9df49a71f01ca0f