### PR TITLE
Improve descriptive text on dynamic links

### DIFF
--- a/js/archive.js
+++ b/js/archive.js
@@ -6,6 +6,7 @@
     resolve: function (value) { return value; }
   };
   var SUMMARY_SOURCES = ['/data/archive/summary.json', 'data/archive/summary.json'];
+  var DEFAULT_ARCHIVE_MONTH_TEXT = 'View archive month';
 
   function ready(fn) {
     if (document.readyState === 'loading') {
@@ -149,6 +150,8 @@
       element.className = 'archive__month';
       var linkFallback = document.createElement('a');
       linkFallback.className = 'archive__month-link';
+      linkFallback.textContent = DEFAULT_ARCHIVE_MONTH_TEXT;
+      linkFallback.setAttribute('aria-label', DEFAULT_ARCHIVE_MONTH_TEXT);
       element.appendChild(linkFallback);
       var metaFallback = document.createElement('span');
       metaFallback.className = 'archive__month-meta';
@@ -160,7 +163,14 @@
 
     if (linkEl) {
       var label = formatMonthLabel(monthInfo && monthInfo.year, monthInfo && monthInfo.month);
-      linkEl.textContent = label || '';
+      var fallbackLabel = (linkEl.textContent || '').trim() || DEFAULT_ARCHIVE_MONTH_TEXT;
+      var appliedLabel = label || fallbackLabel;
+      linkEl.textContent = appliedLabel;
+      if (label) {
+        linkEl.setAttribute('aria-label', 'View archive stories for ' + label);
+      } else {
+        linkEl.setAttribute('aria-label', appliedLabel);
+      }
       var href = buildArchiveUrl(parentKey, childKey, monthInfo && monthInfo.year, monthInfo && monthInfo.month);
       if (href) {
         linkEl.setAttribute('href', href);

--- a/js/e-magz.js
+++ b/js/e-magz.js
@@ -554,11 +554,18 @@ window.initBestOfTheWeekCarousel = bestOfTheWeek;
 				complete: function() {
 				},
 				success: function(data) {
-					$this.find("[data-youtube-id]").each(function(i){
-						var $item = $(this);
-						$item.find(".duration").html(convert_time(data.items[i].contentDetails.duration));
-						$item.find("figure").removeClass("loading").append("<img src='"+data.items[i].snippet.thumbnails.medium.url+"'>");
-						$item.find(".title").removeClass("loading").html(data.items[i].snippet.title);
+                                        $this.find("[data-youtube-id]").each(function(i){
+                                                var $item = $(this);
+                                                var videoData = data && data.items && data.items[i];
+                                                var videoTitle = videoData && videoData.snippet && videoData.snippet.title;
+                                                if(videoTitle) {
+                                                        $item.attr('aria-label', 'Play video: ' + videoTitle);
+                                                }else if(!$item.attr('aria-label')) {
+                                                        $item.attr('aria-label', 'Play video');
+                                                }
+                                                $item.find(".duration").html(convert_time(data.items[i].contentDetails.duration));
+                                                $item.find("figure").removeClass("loading").append("<img src='"+data.items[i].snippet.thumbnails.medium.url+"'>");
+                                                $item.find(".title").removeClass("loading").html(data.items[i].snippet.title);
 						$item.find(".author").removeClass("loading").html(data.items[i].snippet.channelTitle);
 						if($item.data("action") == 'new_tab') {
 							$item.attr('href', 'https://youtube.com/watch?v=' + data.items[i].id).attr('target', '_blank');

--- a/src/site/archive.njk
+++ b/src/site/archive.njk
@@ -42,7 +42,7 @@ description: Dive into AventurOO's archive and browse previous coverage by month
 
 <template data-archive-month-template>
   <li class="archive__month">
-    <a class="archive__month-link" data-archive-month-link href="#"></a>
+    <a class="archive__month-link" data-archive-month-link href="#" aria-label="View archive month">View archive month</a>
     <span class="archive__month-meta" data-archive-month-meta></span>
   </li>
 </template>

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -170,9 +170,9 @@ featuredFallbackSlugs:
                                         </h1>
                                         <div class="aside-body">
                                                 <ul class="video-list" data-youtube='"carousel":true, "nav": "#video-list-nav"'>
-                                                        <li><a data-youtube-id="SBjQ9tuuTJQ" data-action="magnific"></a></li>
-                                                        <li><a data-youtube-id="9cVJr3eQfXc" data-action="magnific"></a></li>
-                                                        <li><a data-youtube-id="DnGdoEa1tPg" data-action="magnific"></a></li>
+                                                        <li><a data-youtube-id="SBjQ9tuuTJQ" data-action="magnific" aria-label="Play video"></a></li>
+                                                        <li><a data-youtube-id="9cVJr3eQfXc" data-action="magnific" aria-label="Play video"></a></li>
+                                                        <li><a data-youtube-id="DnGdoEa1tPg" data-action="magnific" aria-label="Play video"></a></li>
                                                 </ul>
                                         </div>
                                 </aside>


### PR DESCRIPTION
## Summary
- add aria labels to the video list links and populate them with the loaded YouTube title
- give archive month links fallback text and descriptive labels so they remain accessible before data loads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1ddd72fc883339e0eb664f1505b94