### PR TITLE
Lazy load offscreen promotional images

### DIFF
--- a/src/site/_includes/partials/footer.njk
+++ b/src/site/_includes/partials/footer.njk
@@ -6,7 +6,7 @@
           <h1 class="block-title">Info</h1>
           <div class="block-body">
             <figure class="foot-logo">
-              <img src="{{ '/images/logo-light.png' | url }}" class="img-responsive" alt="Logo">
+              <img src="{{ '/images/logo-light.png' | url }}" class="img-responsive" alt="Logo" loading="lazy" decoding="async">
             </figure>
             <p class="brand-description">
               AventurOO — Top News, Tech &amp; AI, Travel &amp; Deals.

--- a/src/site/article.njk
+++ b/src/site/article.njk
@@ -82,7 +82,7 @@ permalink: article.html
                           <div class="aside-body">
                             <figure class="ads">
                               <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
-                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
+                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement" loading="lazy" decoding="async">
                               </a>
                               <figcaption>Advertisement</figcaption>
                             </figure>
@@ -98,7 +98,7 @@ permalink: article.html
                           <div class="aside-body">
                             <figure class="ads">
                               <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
-                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
+                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement" loading="lazy" decoding="async">
                               </a>
                               <figcaption>Advertisement</figcaption>
                             </figure>
@@ -114,7 +114,7 @@ permalink: article.html
                           <div class="aside-body">
                             <figure class="ads">
                               <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
-                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
+                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement" loading="lazy" decoding="async">
                               </a>
                               <figcaption>Advertisement</figcaption>
                             </figure>

--- a/src/site/category.njk
+++ b/src/site/category.njk
@@ -36,7 +36,7 @@ permalink: category.html
                           <div class="aside-body">
                             <figure class="ads">
                               <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
-                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
+                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement" loading="lazy" decoding="async">
                               </a>
                               <figcaption>Advertisement</figcaption>
                             </figure>
@@ -52,7 +52,7 @@ permalink: category.html
                           <div class="aside-body">
                             <figure class="ads">
                               <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
-                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
+                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement" loading="lazy" decoding="async">
                               </a>
                               <figcaption>Advertisement</figcaption>
                             </figure>
@@ -68,7 +68,7 @@ permalink: category.html
                           <div class="aside-body">
                             <figure class="ads">
                               <a href="{{ '/article.html' | url }}?slug={{ site.adFallbackSlug | urlencode }}">
-                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement">
+                                <img src="{{ '/images/ad.png' | url }}" alt="Advertisement" loading="lazy" decoding="async">
                               </a>
                               <figcaption>Advertisement</figcaption>
                             </figure>

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -46,7 +46,7 @@ featuredFallbackSlugs:
                                                 <article class="featured">
                                                         <div class="overlay"></div>
                                                         <figure>
-                                                                <img src="images/news/img14.jpg" alt="Sample Article">
+                                                                <img src="images/news/img14.jpg" alt="Sample Article" loading="lazy" decoding="async">
                                                         </figure>
                                                         <div class="details">
                                                                 <div class="category"><a href="category.html">Travel</a></div>
@@ -59,7 +59,7 @@ featuredFallbackSlugs:
                                                 <article class="featured">
                                                         <div class="overlay"></div>
                                                         <figure>
-                                                                <img src="images/news/img13.jpg" alt="Sample Article">
+                                                                <img src="images/news/img13.jpg" alt="Sample Article" loading="lazy" decoding="async">
                                                         </figure>
                                                         <div class="details">
                                                                 <div class="category"><a href="category.html">International</a></div>
@@ -72,7 +72,7 @@ featuredFallbackSlugs:
                                                 <article class="featured">
                                                         <div class="overlay"></div>
                                                         <figure>
-                                                                <img src="images/news/img05.jpg" alt="Sample Article">
+                                                                <img src="images/news/img05.jpg" alt="Sample Article" loading="lazy" decoding="async">
                                                         </figure>
                                                         <div class="details">
                                                                 <div class="category"><a href="category.html">Lifestyle</a></div>
@@ -96,7 +96,7 @@ featuredFallbackSlugs:
                                 </div>
                                 <div class="banner">
                                         <a href="#">
-                                                <img src="images/ads.png" alt="Sample Article">
+                                                <img src="images/ads.png" alt="Sample Article" loading="lazy" decoding="async">
                                         </a>
                                 </div>
                                 <div class="line transparent little"></div>


### PR DESCRIPTION
## Summary
- defer non-visible featured carousel slides and banner creatives on the homepage
- lazy load sidebar advertisement figures on category and article templates to avoid eager offscreen requests
- mark footer logo as lazy so only above-the-fold assets stay eager

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2bee630e08333a9b5bd4f86aa1ecc