### PR TITLE
Normalize link hashes to ignore fragments

### DIFF
--- a/autopost/pull_news.py
+++ b/autopost/pull_news.py
@@ -362,7 +362,9 @@ def normalize_link(link: str) -> str:
     ]
     query = urlencode(filtered_params, doseq=True)
     normalized = urlunparse(
-        parsed._replace(scheme=scheme, netloc=netloc, path=path, query=query)
+        parsed._replace(
+            scheme=scheme, netloc=netloc, path=path, query=query, fragment=""
+        )
     )
     return normalized
 

--- a/tests/test_pull_news.py
+++ b/tests/test_pull_news.py
@@ -455,5 +455,17 @@ class MaxPerFeedLimitTests(unittest.TestCase):
             pull_news.HOT_PAGE_SIZE = original_hot_page_size
             pull_news.HEADLINE_JSON = original_headline_json
 
+
+class LinkNormalizationTests(unittest.TestCase):
+    def test_link_hash_ignores_fragment(self):
+        with_fragment = "https://example.com/story#ref=rss"
+        without_fragment = "https://example.com/story"
+
+        self.assertEqual(
+            pull_news.link_hash(with_fragment),
+            pull_news.link_hash(without_fragment),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure normalize_link removes URL fragments before hashing
- add a regression test confirming link_hash treats URLs with fragments the same as fragment-free URLs

## Testing
- python -m pytest tests/test_pull_news.py

------
https://chatgpt.com/codex/tasks/task_e_68d2d6d238a48333b3c2bbcfd3e23259