### PR TITLE
Read rotation defaults from config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,12 @@ python scripts/rotate_hot_to_archive.py --retention-days 45
 
 Retention knobs:
 
-- `HOT_RETENTION_DAYS` – number of days to keep in `data/hot` (default: `30`).
+- `config.json` → `window_days` – fallback retention window when no CLI or
+  environment overrides are provided.
+- `config.json` → `archive_on_days` – exported for schedulers/cron jobs that
+  coordinate how frequently the rotation should run.
+- `HOT_RETENTION_DAYS` – overrides the retention window from `window_days` when
+  set (defaulting to the config value).
 - `HOT_PAGINATION_SIZE` – pagination size used when computing manifest counts
   (default: `12`).
 


### PR DESCRIPTION
## Summary
- load config.json so rotate_hot_to_archive can read window_days and archive_on_days with helpful warnings when the file is missing or invalid
- use the configured window_days for default retention and expose the archive_on_days helper for scheduling consumers
- document the configuration-driven behaviour and add regression tests that cover these code paths

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2f9344adc8333ab8240447a550474