### PR TITLE
Simplify autopost workflow

### DIFF
--- a/.github/workflows/autopost.yml
+++ b/.github/workflows/autopost.yml
@@ -3,7 +3,7 @@ name: Autopost
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "0 */3 * * *"
+    - cron: "0 */6 * * *"
 
 permissions:
   contents: write
@@ -13,77 +13,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  ingest:
-    name: Ingest ${{ matrix.name }}
+  autopost:
+    name: Run autopost pipeline
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        include:
-          - name: News
-            script: pull_news.py
-            feeds: autopost/feeds_news.txt
-            category: News
-            summary_words: "900"
-            order: "01"
-          - name: "Business & Finance"
-            script: pull_news.py
-            feeds: autopost/feeds_news.txt
-            category: "Business & Finance"
-            summary_words: "900"
-            order: "02"
-          - name: Crypto
-            script: pull_crypto.py
-            feeds: autopost/feeds_crypto.txt
-            category: Crypto
-            summary_words: "900"
-            order: "03"
-          - name: Culture & Arts
-            script: pull_cultute_arts.py
-            feeds: autopost/feeds_cultute_arts.txt
-            category: "Culture & Arts"
-            summary_words: "900"
-            order: "04"
-          - name: Entertainment
-            script: pull_entertainment.py
-            feeds: autopost/feeds_entertainment.txt
-            category: Entertainment
-            summary_words: "900"
-            order: "05"
-          - name: Food & Drink
-            script: pull_food_drink.py
-            feeds: autopost/feeds_food_drink.txt
-            category: "Food & Drink"
-            summary_words: "900"
-            order: "06"
-          - name: Lifestyle
-            script: pull_lifestyle.py
-            feeds: autopost/feeds_lifestyle.txt
-            category: Lifestyle
-            summary_words: "900"
-            order: "07"
-          - name: Tech & AI
-            script: pull_tech_ai.py
-            feeds: autopost/feeds_tech_ai.txt
-            category: "Tech & AI"
-            summary_words: "900"
-            order: "08"
-          - name: Travel
-            script: pull_travel.py
-            feeds: autopost/feeds_travel.txt
-            category: Travel
-            summary_words: "900"
-            order: "09"
-    env:
-      SUMMARY_WORDS: ${{ matrix.summary_words }}
-      HTTP_TIMEOUT: "18"
-      AP_USER_AGENT: "Mozilla/5.0 (AventurOO Autoposter)"
-      FALLBACK_COVER: "assets/img/cover-fallback.jpg"
-      FEEDS_FILE: ${{ matrix.feeds }}
-      CATEGORY: ${{ matrix.category }}
-      HOT_RETENTION_DAYS: "30"
-      HOT_PAGINATION_SIZE: "12"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -100,98 +32,18 @@ jobs:
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: npm
+      - name: Run autopost pipeline
+        run: python scripts/your_autopost_pipeline.py
 
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade 'pip<24.3'
-          pip install trafilatura readability-lxml lxml certifi
+      - name: Build feeds
+        run: python scripts/build_feeds.py
 
-      - name: Restore autopost state marker
-        if: ${{ matrix.order != '01' }}
-        id: prev
-        shell: bash
-        env:
-          MATRIX_ORDER: ${{ matrix.order }}
-        run: |
-          current=${MATRIX_ORDER#0}
-          if [ -z "$current" ]; then
-            current=0
-          fi
-          prev=$(printf '%02d' $((current - 1)))
-          echo "name=autopost-state-${prev}" >> "$GITHUB_OUTPUT"
-
-      - name: Download previous autopost state
-        if: ${{ matrix.order != '01' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ steps.prev.outputs.name }}
-          path: autopost-state
-
-      - name: Apply previous autopost state
-        if: ${{ matrix.order != '01' }}
-        run: |
-          rsync -a autopost-state/ ./
-          rm -rf autopost-state
-
-      - name: Install Node dependencies
-        run: npm ci
-
-      - name: Run autoposter
-        run: python autopost/${{ matrix.script }}
-
-      - name: Rotate hot shards into archive
-        run: python scripts/rotate_hot_to_archive.py
-
-      - name: Build site
-        run: npm run build
-
-      - name: Compress site assets
-        run: npm run postbuild
-
-      - name: Persist autopost state
+      - name: Upload autopost debug artifact
         uses: actions/upload-artifact@v4
         with:
-          name: autopost-state-${{ matrix.order }}
-          retention-days: 3
-          path: |
-            _site
-            _health
-            data
-            autopost/seen_all.json
-
-  commit:
-    name: Commit updated content
-    runs-on: ubuntu-latest
-    needs: ingest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Sync branch head
-        shell: bash
-        run: |
-          set -euo pipefail
-          git fetch origin
-          git reset --hard "origin/${GITHUB_REF_NAME:-${GITHUB_HEAD_REF:-main}}"
-
-      - name: Download autopost states
-        uses: actions/download-artifact@v4
-        with:
-          pattern: autopost-state-*
-          path: autopost-artifacts
-          merge-multiple: false
-
-      - name: Apply latest autopost state
-        run: |
-          set -euo pipefail
-          latest=$(ls autopost-artifacts | sort | tail -n1)
-          rsync -a "autopost-artifacts/${latest}/" ./
-          rm -rf autopost-artifacts
+          name: autopost-debug
+          path: data/index.json
+          retention-days: 1
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary
- update the autopost schedule to run every six hours
- replace the multi-matrix ingest/commit process with a single Python-based pipeline job
- upload the generated feed index as an artifact and guard commits so they only push when changes exist

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3071d12b88333829dea6e5402158c