### PR TITLE
Add scheduled archive workflow

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,65 @@
+name: Archive feeds
+
+on:
+  schedule:
+    - cron: '0 2 1,16 * *'
+  workflow_dispatch:
+
+jobs:
+  archive:
+    name: Run archive feeds script
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          echo "Checking for requirements file before installing dependencies..."
+          if [ -f requirements.txt ]; then
+            echo "requirements.txt found. Installing dependencies..."
+            pip install --upgrade pip
+            pip install -r requirements.txt
+            echo "Dependency installation completed."
+          else
+            echo "No requirements.txt found. Skipping dependency installation."
+          fi
+
+      - name: Run archive script
+        run: |
+          echo "Starting archive script..."
+          python scripts/archive_feeds.py
+          echo "Archive script finished."
+
+      - name: Commit and push changes
+        run: |
+          echo "Checking for repository changes..."
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes detected. Nothing to commit."
+            exit 0
+          fi
+
+          echo "Changes detected. Preparing to commit and push..."
+          echo "Repository changes:"
+          git status --short
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          echo "Staging changes..."
+          git add -A
+
+          echo "Committing changes..."
+          git commit -m "chore: archive feed updates"
+
+          echo "Pushing changes to repository..."
+          git push
+          echo "Changes pushed successfully."


### PR DESCRIPTION
## Summary
- add a scheduled workflow that runs the archive script twice monthly and supports manual triggers
- ensure the workflow installs dependencies, runs the script, and commits any changes back to the repository

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d30b9d8c00833385c69f557ae23064