### PR TITLE
Add Netlify headers configuration

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,6 +16,8 @@ module.exports = function (eleventyConfig) {
     eleventyConfig.addPassthroughCopy(path);
   });
 
+  eleventyConfig.addPassthroughCopy({ "src/site/_headers": "_headers" });
+
   eleventyConfig.addFilter("toAbsoluteUrl", (url, base) => {
     if (!url) {
       return url;

--- a/src/site/_headers
+++ b/src/site/_headers
@@ -1,0 +1,7 @@
+/data/archive/*
+  Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
+
+/data/*
+  Cache-Control: public, max-age=86400, immutable
+  Access-Control-Allow-Origin: *


### PR DESCRIPTION
## Summary
- add a `_headers` file under `src/site` to define caching headers for data endpoints
- configure Eleventy to passthrough-copy the `_headers` file so Netlify receives it during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d31518a3208333a768293599949d17