### PR TITLE
Add dynamic category data loader and template updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,41 @@ This generates the static site inside the `_site/` directory. The default
 `.json` output (including the archive/search trees) into `.gz` siblings so that
 the CDN can serve precompressed responses.
 
+## Client-side category loader helpers
+
+The global `assets/js/data-loader.js` script hydrates the navigation menu and
+category feeds once the DOM is ready. A minimal HTML scaffold looks like:
+
+```html
+<nav class="menu">
+  <div data-category-menu></div>
+</nav>
+
+<section class="category" data-category-feed data-category="news">
+  <ul class="row list-unstyled" data-post-list></ul>
+  <p class="text-muted" data-load-more-status aria-live="polite"></p>
+  <button
+    type="button"
+    class="btn btn-primary"
+    data-load-more
+    data-label="Load more"
+    data-loading-label="Loading…"
+  >Load more</button>
+</section>
+
+<script>
+  window.__AVENTUROO_BASE_PATH__ = '';
+</script>
+<script src="/js/base-path.js"></script>
+<script src="/assets/js/data-loader.js" defer></script>
+```
+
+The loader resolves URLs through `window.AventurOOBasePath`, fetches
+`/data/index.json` to populate the menu, requests
+`/data/categories/<slug>/index.json` for the initial post list, and uses the
+`data-load-more` button to walk the archive queue exposed via
+`/data/archive/<slug>/<YYYY>/<MM>.json`.
+
 ## Running the autopost scripts
 
 Each autopost module (news, travel, entertainment, etc.) lives in the

--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -1,0 +1,1115 @@
+(function (window, document) {
+  'use strict';
+
+  if (!window || !document) {
+    return;
+  }
+
+  var fetchFn = typeof window.fetch === 'function' ? window.fetch.bind(window) : null;
+  var baseHelper = window.AventurOOBasePath || null;
+  var archiveSummaryPromise = null;
+  var categoryState = null;
+
+  function resolve(path) {
+    if (typeof path !== 'string') {
+      return path;
+    }
+    if (baseHelper && typeof baseHelper.resolve === 'function') {
+      return baseHelper.resolve(path);
+    }
+    return path;
+  }
+
+  var DEFAULT_IMAGE = resolve('/images/logo.png');
+
+  function ready(callback) {
+    if (typeof callback !== 'function') {
+      return;
+    }
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback, false);
+    } else {
+      callback();
+    }
+  }
+
+  function getString(value) {
+    if (value == null) {
+      return '';
+    }
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (typeof value === 'number') {
+      return String(value);
+    }
+    return '';
+  }
+
+  function fetchJson(path, options) {
+    if (!fetchFn) {
+      return Promise.reject(new Error('Fetch API is not available.'));
+    }
+    var url = resolve(path);
+    var settings = { credentials: 'same-origin' };
+    if (options && typeof options === 'object') {
+      for (var key in options) {
+        if (Object.prototype.hasOwnProperty.call(options, key)) {
+          settings[key] = options[key];
+        }
+      }
+    }
+    return fetchFn(url, settings).then(function (response) {
+      if (!response || !response.ok) {
+        var status = response ? response.status : '0';
+        throw new Error('Request failed with status ' + status);
+      }
+      return response.json();
+    });
+  }
+
+  function normalizeSlug(value) {
+    if (value == null) {
+      return '';
+    }
+    var str = String(value).trim();
+    if (!str) {
+      return '';
+    }
+    var lowered = str.toLowerCase();
+    if (lowered.indexOf('/') !== -1) {
+      var segments = lowered.split('/');
+      var cleaned = [];
+      for (var i = 0; i < segments.length; i++) {
+        var part = slugifySegment(segments[i]);
+        if (part) {
+          cleaned.push(part);
+        }
+      }
+      return cleaned.join('/');
+    }
+    if (/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(lowered)) {
+      return lowered;
+    }
+    return slugifySegment(lowered);
+  }
+
+  function slugifySegment(value) {
+    return String(value || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  function matchesSlug(candidate, target) {
+    var normalizedCandidate = normalizeSlug(candidate);
+    var normalizedTarget = normalizeSlug(target);
+    if (!normalizedCandidate || !normalizedTarget) {
+      return false;
+    }
+    if (normalizedCandidate === normalizedTarget) {
+      return true;
+    }
+    var candidateParts = normalizedCandidate.split('/');
+    var targetParts = normalizedTarget.split('/');
+    return candidateParts[candidateParts.length - 1] === targetParts[targetParts.length - 1];
+  }
+
+  function normalizePath(pathname) {
+    if (!pathname) {
+      return '/';
+    }
+    var path = String(pathname).split(/[?#]/)[0];
+    path = path.replace(/\/+$/, '');
+    if (!path) {
+      return '/';
+    }
+    return path;
+  }
+
+  function monthLabel(year, month) {
+    var y = parseInt(year, 10);
+    var m = parseInt(month, 10);
+    if (!y || !m) {
+      return '';
+    }
+    var date = new Date(Date.UTC(y, m - 1, 1));
+    if (isNaN(date.getTime())) {
+      return y + '-' + (m < 10 ? '0' + m : m);
+    }
+    var formatter;
+    try {
+      formatter = date.toLocaleString(undefined, { month: 'long', year: 'numeric' });
+    } catch (err) {
+      formatter = y + '-' + (m < 10 ? '0' + m : m);
+    }
+    return formatter;
+  }
+
+  function padMonth(value) {
+    var num = parseInt(value, 10);
+    if (!num || num < 1) {
+      return '01';
+    }
+    return num < 10 ? '0' + num : String(num);
+  }
+
+  function Deduper() {
+    this._seen = Object.create(null);
+  }
+
+  Deduper.prototype._keysFor = function (post) {
+    var keys = [];
+    if (!post || typeof post !== 'object') {
+      return keys;
+    }
+    var id = getString(post.id);
+    if (id) {
+      keys.push('id:' + id);
+    }
+    var slug = getString(post.slug);
+    if (slug) {
+      keys.push('slug:' + slug.toLowerCase());
+    }
+    var url = getString(post.url || post.link || post.permalink);
+    if (url) {
+      keys.push('url:' + url);
+    }
+    var guid = getString(post.guid);
+    if (guid) {
+      keys.push('guid:' + guid);
+    }
+    var title = getString(post.title).trim();
+    var date = getString(post.date || post.published_at || post.pubDate || post.published || post.datetime).trim();
+    if (title) {
+      keys.push('title-date:' + title + '|' + date);
+    }
+    return keys;
+  };
+
+  Deduper.prototype.add = function (post) {
+    var keys = this._keysFor(post);
+    if (!keys.length) {
+      return true;
+    }
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      if (key && this._seen[key]) {
+        return false;
+      }
+    }
+    for (var j = 0; j < keys.length; j++) {
+      var k = keys[j];
+      if (k) {
+        this._seen[k] = true;
+      }
+    }
+    return true;
+  };
+
+  function extractPosts(payload) {
+    if (!payload || typeof payload !== 'object') {
+      return [];
+    }
+    if (Array.isArray(payload.posts)) {
+      return payload.posts;
+    }
+    if (Array.isArray(payload.items)) {
+      return payload.items;
+    }
+    if (payload.data) {
+      if (Array.isArray(payload.data.posts)) {
+        return payload.data.posts;
+      }
+      if (Array.isArray(payload.data.items)) {
+        return payload.data.items;
+      }
+    }
+    if (Array.isArray(payload.results)) {
+      return payload.results;
+    }
+    if (payload.results && Array.isArray(payload.results.items)) {
+      return payload.results.items;
+    }
+    if (payload.page && Array.isArray(payload.page.items)) {
+      return payload.page.items;
+    }
+    if (payload.pagination && Array.isArray(payload.pagination.items)) {
+      return payload.pagination.items;
+    }
+    return [];
+  }
+
+  function extractArchiveQueue(payload) {
+    var queue = [];
+    if (!payload || typeof payload !== 'object') {
+      return queue;
+    }
+    var sources = [];
+    if (Array.isArray(payload.archive)) {
+      sources.push(payload.archive);
+    }
+    if (payload.archive && Array.isArray(payload.archive.months)) {
+      sources.push(payload.archive.months);
+    }
+    if (Array.isArray(payload.archives)) {
+      sources.push(payload.archives);
+    }
+    if (Array.isArray(payload.months)) {
+      sources.push(payload.months);
+    }
+    if (payload.meta && Array.isArray(payload.meta.months)) {
+      sources.push(payload.meta.months);
+    }
+    if (payload.pagination && Array.isArray(payload.pagination.months)) {
+      sources.push(payload.pagination.months);
+    }
+    var seen = Object.create(null);
+    for (var i = 0; i < sources.length; i++) {
+      var list = sources[i];
+      if (!Array.isArray(list)) {
+        continue;
+      }
+      for (var j = 0; j < list.length; j++) {
+        var entry = list[j];
+        if (!entry || typeof entry !== 'object') {
+          continue;
+        }
+        var year = parseInt(entry.year, 10);
+        var month = parseInt(entry.month, 10);
+        if (!year || !month) {
+          continue;
+        }
+        var key = year + '-' + month;
+        if (seen[key]) {
+          continue;
+        }
+        seen[key] = true;
+        queue.push({ year: year, month: month });
+      }
+    }
+    return queue;
+  }
+
+  function getArchiveSummary() {
+    if (!archiveSummaryPromise) {
+      archiveSummaryPromise = fetchJson('/data/archive/summary.json', { cache: 'no-store' })
+        .catch(function (err) {
+          console.warn('Archive summary load failed:', err);
+          return null;
+        });
+    }
+    return archiveSummaryPromise;
+  }
+
+  function findArchiveMonths(summary, slug) {
+    var result = [];
+    var normalizedSlug = normalizeSlug(slug);
+    if (!summary || !normalizedSlug) {
+      return result;
+    }
+    var seen = Object.create(null);
+
+    function appendMonths(list) {
+      if (!Array.isArray(list)) {
+        return;
+      }
+      for (var i = 0; i < list.length; i++) {
+        var entry = list[i];
+        if (!entry) {
+          continue;
+        }
+        var year = parseInt(entry.year, 10);
+        var month = parseInt(entry.month, 10);
+        if (!year || !month) {
+          continue;
+        }
+        var key = year + '-' + month;
+        if (seen[key]) {
+          continue;
+        }
+        seen[key] = true;
+        result.push({ year: year, month: month });
+      }
+    }
+
+    if (Array.isArray(summary.parents)) {
+      for (var i = 0; i < summary.parents.length; i++) {
+        var parent = summary.parents[i];
+        if (!parent) {
+          continue;
+        }
+        if (matchesSlug(parent.slug || parent.parent, normalizedSlug)) {
+          appendMonths(parent.months);
+        }
+        if (Array.isArray(parent.children)) {
+          for (var j = 0; j < parent.children.length; j++) {
+            var child = parent.children[j];
+            if (!child) {
+              continue;
+            }
+            var childSlug = child.slug || child.child;
+            if (!childSlug && matchesSlug(parent.slug || parent.parent, normalizedSlug)) {
+              childSlug = parent.parent + '/' + (child.child || '');
+            }
+            if (matchesSlug(childSlug, normalizedSlug)) {
+              appendMonths(child.months);
+            }
+          }
+        }
+      }
+    }
+
+    if (!result.length && Array.isArray(summary.children)) {
+      for (var k = 0; k < summary.children.length; k++) {
+        var direct = summary.children[k];
+        if (direct && matchesSlug(direct.slug || direct.child, normalizedSlug)) {
+          appendMonths(direct.months);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  function buildMenuConfig(payload) {
+    var config = { items: [], tabletHeader: null };
+    if (!payload || typeof payload !== 'object') {
+      return config;
+    }
+    var menu = payload.menu || payload.navigation || null;
+    if (Array.isArray(menu)) {
+      config.items = menu.slice();
+      if (payload.tabletHeader) {
+        config.tabletHeader = payload.tabletHeader;
+      }
+    } else if (menu && typeof menu === 'object') {
+      if (Array.isArray(menu.items)) {
+        config.items = menu.items.slice();
+      }
+      if (menu.tabletHeader) {
+        config.tabletHeader = menu.tabletHeader;
+      }
+    }
+    if (!config.items.length) {
+      if (Array.isArray(payload.items)) {
+        config.items = payload.items.slice();
+      } else if (Array.isArray(payload.categories)) {
+        config.items = payload.categories.slice();
+      }
+    }
+    return config;
+  }
+
+  function normalizeMenuChildren(source) {
+    if (!source) {
+      return [];
+    }
+    if (Array.isArray(source)) {
+      return source;
+    }
+    if (typeof source === 'object') {
+      var items = [];
+      for (var key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+          items.push(source[key]);
+        }
+      }
+      return items;
+    }
+    return [];
+  }
+
+  function normalizeMenuItem(raw) {
+    if (!raw || typeof raw !== 'object') {
+      return null;
+    }
+    var item = {
+      title: getString(raw.title || raw.name || raw.label || raw.slug || ''),
+      slug: normalizeSlug(raw.slug || raw.id || ''),
+      href: getString(raw.href || raw.url || raw.link || ''),
+      target: getString(raw.target || ''),
+      badge: getString(raw.badge || ''),
+      icon: getString(raw.icon || ''),
+      children: []
+    };
+
+    if (item.href) {
+      item.href = resolve(item.href);
+    } else if (item.slug) {
+      if (baseHelper && typeof baseHelper.categoryUrl === 'function') {
+        item.href = baseHelper.categoryUrl(item.slug);
+      } else {
+        item.href = resolve('/category.html?cat=' + encodeURIComponent(item.slug));
+      }
+    }
+
+    var childrenSource = normalizeMenuChildren(raw.children || raw.items || raw.categories);
+    for (var i = 0; i < childrenSource.length; i++) {
+      var child = normalizeMenuItem(childrenSource[i]);
+      if (child) {
+        item.children.push(child);
+      }
+    }
+
+    if (!item.children.length && Array.isArray(raw.megaColumns)) {
+      for (var colIndex = 0; colIndex < raw.megaColumns.length; colIndex++) {
+        var column = raw.megaColumns[colIndex];
+        if (!column) {
+          continue;
+        }
+        var links = normalizeMenuChildren(column.links);
+        for (var linkIndex = 0; linkIndex < links.length; linkIndex++) {
+          var colItem = normalizeMenuItem(links[linkIndex]);
+          if (colItem) {
+            item.children.push(colItem);
+          }
+        }
+      }
+    }
+
+    return item;
+  }
+
+  function createMenuList(items, level) {
+    if (!items || !items.length) {
+      return null;
+    }
+    var ul = document.createElement('ul');
+    if (level === 0) {
+      ul.className = 'nav-list';
+    } else {
+      ul.className = 'nav-sublist dropdown-menu';
+    }
+    for (var i = 0; i < items.length; i++) {
+      var item = items[i];
+      if (!item) {
+        continue;
+      }
+      var li = document.createElement('li');
+      if (item.children && item.children.length) {
+        if (level === 0) {
+          li.className = 'dropdown magz-dropdown';
+        } else {
+          li.className = 'dropdown';
+        }
+      }
+      var link;
+      if (item.href) {
+        link = document.createElement('a');
+        link.href = item.href;
+        if (item.target) {
+          link.target = item.target;
+        }
+        if (item.icon) {
+          var icon = document.createElement('i');
+          icon.className = item.icon;
+          link.appendChild(icon);
+          link.appendChild(document.createTextNode(' '));
+        }
+        link.appendChild(document.createTextNode(item.title || ''));
+        if (item.badge) {
+          var badge = document.createElement('div');
+          badge.className = 'badge';
+          badge.textContent = item.badge;
+          link.appendChild(badge);
+        }
+        if (item.children && item.children.length) {
+          link.appendChild(document.createTextNode(' '));
+          var caret = document.createElement('i');
+          caret.className = 'ion-ios-arrow-right';
+          caret.setAttribute('aria-hidden', 'true');
+          link.appendChild(caret);
+        }
+        li.appendChild(link);
+      } else {
+        var span = document.createElement('span');
+        span.textContent = item.title || '';
+        li.appendChild(span);
+      }
+      if (item.children && item.children.length) {
+        var childList = createMenuList(item.children, level + 1);
+        if (childList) {
+          li.appendChild(childList);
+        }
+      }
+      ul.appendChild(li);
+    }
+    return ul;
+  }
+
+  function addTabletHeader(list, header) {
+    if (!list || !header) {
+      return;
+    }
+    var show = header.show;
+    if (show === false) {
+      return;
+    }
+    var title = getString(header.title) || 'Menu';
+    var loginHref = getString(header.loginHref || header.login) || 'login.html';
+    var registerHref = getString(header.registerHref || header.register) || 'register.html';
+
+    var titleItem = document.createElement('li');
+    titleItem.className = 'for-tablet nav-title';
+    var titleLink = document.createElement('a');
+    titleLink.href = '#';
+    titleLink.textContent = title;
+    titleItem.appendChild(titleLink);
+
+    var loginItem = document.createElement('li');
+    loginItem.className = 'for-tablet';
+    var loginLink = document.createElement('a');
+    loginLink.href = resolve(loginHref);
+    loginLink.textContent = getString(header.loginLabel) || 'Login';
+    loginItem.appendChild(loginLink);
+
+    var registerItem = document.createElement('li');
+    registerItem.className = 'for-tablet';
+    var registerLink = document.createElement('a');
+    registerLink.href = resolve(registerHref);
+    registerLink.textContent = getString(header.registerLabel) || 'Register';
+    registerItem.appendChild(registerLink);
+
+    if (list.firstChild) {
+      list.insertBefore(titleItem, list.firstChild);
+      list.insertBefore(loginItem, titleItem.nextSibling);
+      list.insertBefore(registerItem, loginItem.nextSibling);
+    } else {
+      list.appendChild(titleItem);
+      list.appendChild(loginItem);
+      list.appendChild(registerItem);
+    }
+  }
+
+  function applyActiveState(list) {
+    if (!list) {
+      return;
+    }
+    var links = list.querySelectorAll('a[href]');
+    if (!links || !links.length) {
+      return;
+    }
+    var currentPath = normalizePath(window.location.pathname);
+    var best = { score: -1, link: null };
+
+    function scoreFor(href) {
+      if (!href) {
+        return -1;
+      }
+      var resolved;
+      try {
+        resolved = new URL(href, window.location.origin).pathname;
+      } catch (err) {
+        return -1;
+      }
+      var normalized = normalizePath(resolved);
+      if (normalized === currentPath) {
+        return normalized.length + 1000;
+      }
+      if (normalized !== '/' && currentPath.indexOf(normalized + '/') === 0) {
+        return normalized.length;
+      }
+      return -1;
+    }
+
+    for (var i = 0; i < links.length; i++) {
+      var link = links[i];
+      var score = scoreFor(link.getAttribute('href'));
+      if (score > best.score) {
+        best.score = score;
+        best.link = link;
+      }
+    }
+
+    if (best.link) {
+      var li = best.link.closest('li');
+      while (li) {
+        li.classList.add('active');
+        li = li.parentElement ? li.parentElement.closest('li') : null;
+      }
+    }
+  }
+
+  function renderMenu(payload) {
+    var containers = document.querySelectorAll('[data-category-menu]');
+    if (!containers.length) {
+      return;
+    }
+    var config = buildMenuConfig(payload);
+    var normalizedItems = [];
+    for (var i = 0; i < config.items.length; i++) {
+      var normalized = normalizeMenuItem(config.items[i]);
+      if (normalized) {
+        normalizedItems.push(normalized);
+      }
+    }
+    if (!normalizedItems.length) {
+      return;
+    }
+    for (var j = 0; j < containers.length; j++) {
+      var container = containers[j];
+      while (container.firstChild) {
+        container.removeChild(container.firstChild);
+      }
+      var list = createMenuList(normalizedItems, 0);
+      if (list) {
+        addTabletHeader(list, config.tabletHeader);
+        container.appendChild(list);
+        applyActiveState(list);
+      }
+    }
+  }
+
+  function initMenu() {
+    if (!document.querySelector('[data-category-menu]')) {
+      return;
+    }
+    fetchJson('/data/index.json', { cache: 'no-store' })
+      .then(renderMenu)
+      .catch(function (err) {
+        console.warn('Category menu load failed:', err);
+      });
+  }
+
+  function readCategorySlug(section) {
+    if (!section) {
+      return '';
+    }
+    var attr = section.getAttribute('data-category') || section.dataset.category;
+    if (attr) {
+      return normalizeSlug(attr);
+    }
+    var search = window.location.search || '';
+    var params;
+    try {
+      params = new URLSearchParams(search);
+    } catch (err) {
+      return '';
+    }
+    var fromQuery = params.get('cat') || params.get('category') || params.get('slug');
+    return normalizeSlug(fromQuery);
+  }
+
+  function resolveArticleUrl(post) {
+    if (!post || typeof post !== 'object') {
+      return '#';
+    }
+    var direct = getString(post.url || post.link || post.permalink);
+    if (direct) {
+      return resolve(direct);
+    }
+    var slug = getString(post.slug || post.id);
+    if (slug) {
+      if (baseHelper && typeof baseHelper.articleUrl === 'function') {
+        return baseHelper.articleUrl(slug);
+      }
+      return resolve('/article.html?slug=' + encodeURIComponent(slug));
+    }
+    var guid = getString(post.guid || post.canonical || post.source);
+    if (guid) {
+      return guid;
+    }
+    return '#';
+  }
+
+  function resolveCategoryName(post) {
+    if (!post || typeof post !== 'object') {
+      return '';
+    }
+    var candidates = [
+      post.category_label,
+      post.categoryLabel,
+      post.category_title,
+      post.categoryTitle,
+      post.category,
+      post.section,
+      post.section_name,
+      post.subcategory
+    ];
+    for (var i = 0; i < candidates.length; i++) {
+      var name = getString(candidates[i]).trim();
+      if (name) {
+        return name;
+      }
+    }
+    return '';
+  }
+
+  function resolveCategorySlug(post) {
+    if (!post || typeof post !== 'object') {
+      return '';
+    }
+    var candidates = [
+      post.category_slug,
+      post.categorySlug,
+      post.category_path,
+      post.categoryPath,
+      post.section_slug,
+      post.subcategory_slug,
+      post.subcategorySlug
+    ];
+    for (var i = 0; i < candidates.length; i++) {
+      var slug = normalizeSlug(candidates[i]);
+      if (slug) {
+        return slug;
+      }
+    }
+    var fallback = getString(post.category);
+    if (fallback) {
+      return normalizeSlug(fallback);
+    }
+    return '';
+  }
+
+  function buildCategoryUrl(slug) {
+    var normalized = normalizeSlug(slug);
+    if (!normalized) {
+      return '#';
+    }
+    if (baseHelper && typeof baseHelper.categoryUrl === 'function') {
+      return baseHelper.categoryUrl(normalized);
+    }
+    return resolve('/category.html?cat=' + encodeURIComponent(normalized));
+  }
+
+  function formatDisplayDate(value) {
+    if (!value) {
+      return '';
+    }
+    var date;
+    try {
+      date = new Date(value);
+    } catch (err) {
+      date = null;
+    }
+    if (date && !isNaN(date.getTime())) {
+      try {
+        return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+      } catch (err2) {
+        return date.getUTCFullYear() + '-' + padMonth(date.getUTCMonth() + 1) + '-' + padMonth(date.getUTCDate());
+      }
+    }
+    return String(value);
+  }
+
+  function removeEmptyState(list) {
+    var empties = list ? list.querySelectorAll('.empty-state') : [];
+    for (var i = 0; i < empties.length; i++) {
+      var node = empties[i];
+      if (node && node.parentNode) {
+        node.parentNode.removeChild(node);
+      }
+    }
+  }
+
+  function showEmptyState(list, text) {
+    if (!list) {
+      return;
+    }
+    var item = document.createElement('li');
+    item.className = 'empty-state text-muted';
+    item.textContent = text;
+    list.appendChild(item);
+  }
+
+  function createPostNode(post) {
+    if (!post) {
+      return null;
+    }
+    var li = document.createElement('li');
+    li.className = 'col-md-12 article-list';
+
+    var article = document.createElement('article');
+    article.className = 'article';
+
+    var inner = document.createElement('div');
+    inner.className = 'inner';
+
+    var figure = document.createElement('figure');
+    var cover = getString(post.cover || post.image || post.thumbnail);
+    if (!cover) {
+      figure.className = 'no-cover';
+    }
+    var figureLink = document.createElement('a');
+    var articleUrl = resolveArticleUrl(post);
+    figureLink.href = articleUrl;
+    var img = document.createElement('img');
+    img.src = cover ? resolve(cover) : DEFAULT_IMAGE;
+    img.alt = getString(post.title) || 'Article cover';
+    figureLink.appendChild(img);
+    figure.appendChild(figureLink);
+    inner.appendChild(figure);
+
+    var details = document.createElement('div');
+    details.className = 'details';
+
+    var detailMeta = document.createElement('div');
+    detailMeta.className = 'detail';
+
+    var categoryName = resolveCategoryName(post);
+    var categorySlug = resolveCategorySlug(post);
+    if (categoryName) {
+      var categoryDiv = document.createElement('div');
+      categoryDiv.className = 'category';
+      if (categorySlug) {
+        var categoryLink = document.createElement('a');
+        categoryLink.href = buildCategoryUrl(categorySlug);
+        categoryLink.textContent = categoryName;
+        categoryDiv.appendChild(categoryLink);
+      } else {
+        categoryDiv.textContent = categoryName;
+      }
+      detailMeta.appendChild(categoryDiv);
+    }
+
+    var timeDiv = document.createElement('div');
+    timeDiv.className = 'time';
+    timeDiv.textContent = formatDisplayDate(post.date || post.published_at || post.pubDate || post.updated_at);
+    detailMeta.appendChild(timeDiv);
+    details.appendChild(detailMeta);
+
+    var heading = document.createElement('h1');
+    var headingLink = document.createElement('a');
+    headingLink.href = articleUrl;
+    headingLink.textContent = getString(post.title) || 'Untitled';
+    heading.appendChild(headingLink);
+    details.appendChild(heading);
+
+    var excerpt = getString(post.excerpt || post.summary || post.description).trim();
+    if (excerpt) {
+      var paragraph = document.createElement('p');
+      paragraph.textContent = excerpt;
+      details.appendChild(paragraph);
+    }
+
+    var footer = document.createElement('footer');
+    var moreLink = document.createElement('a');
+    moreLink.className = 'btn btn-primary more';
+    moreLink.href = articleUrl;
+    var moreInner = document.createElement('div');
+    moreInner.textContent = 'More';
+    var iconWrap = document.createElement('div');
+    var icon = document.createElement('i');
+    icon.className = 'ion-ios-arrow-thin-right';
+    iconWrap.appendChild(icon);
+    moreLink.appendChild(moreInner);
+    moreLink.appendChild(iconWrap);
+    footer.appendChild(moreLink);
+    details.appendChild(footer);
+
+    inner.appendChild(details);
+    article.appendChild(inner);
+    li.appendChild(article);
+    return li;
+  }
+
+  function appendPosts(state, posts) {
+    if (!state || !state.postList) {
+      return 0;
+    }
+    if (!state.initialised) {
+      state.postList.innerHTML = '';
+      state.initialised = true;
+    }
+    removeEmptyState(state.postList);
+    var fragment = document.createDocumentFragment();
+    var added = 0;
+    for (var i = 0; i < posts.length; i++) {
+      var post = posts[i];
+      if (!state.deduper.add(post)) {
+        continue;
+      }
+      var node = createPostNode(post);
+      if (node) {
+        fragment.appendChild(node);
+        added += 1;
+      }
+    }
+    if (added) {
+      state.postList.appendChild(fragment);
+    }
+    return added;
+  }
+
+  function setStatus(statusEl, message) {
+    if (!statusEl) {
+      return;
+    }
+    statusEl.textContent = message || '';
+  }
+
+  function updateLoadMoreButton(state) {
+    if (!state || !state.button) {
+      return;
+    }
+    var label = state.button.getAttribute('data-label');
+    if (!label) {
+      label = 'Load more';
+      state.button.setAttribute('data-label', label);
+    }
+    var loadingLabel = state.button.getAttribute('data-loading-label') || 'Loading…';
+
+    if (state.isLoading) {
+      state.button.disabled = true;
+      state.button.setAttribute('aria-busy', 'true');
+      state.button.textContent = loadingLabel;
+      return;
+    }
+
+    state.button.removeAttribute('aria-busy');
+    state.button.textContent = label;
+    if (!state.queue || !state.queue.length) {
+      state.button.disabled = true;
+      state.button.setAttribute('aria-disabled', 'true');
+    } else {
+      state.button.disabled = false;
+      state.button.removeAttribute('aria-disabled');
+    }
+  }
+
+  function handleCategoryPayload(state, payload) {
+    var posts = extractPosts(payload);
+    var added = appendPosts(state, posts);
+    if (!added) {
+      showEmptyState(state.postList, 'No posts available for this category yet.');
+      setStatus(state.statusEl, 'No posts found for this category.');
+    } else {
+      setStatus(state.statusEl, 'Loaded ' + added + ' posts.');
+    }
+    var directQueue = extractArchiveQueue(payload);
+    if (directQueue.length) {
+      state.queue = directQueue;
+      updateLoadMoreButton(state);
+    } else if (state.button) {
+      getArchiveSummary().then(function (summary) {
+        if (!summary) {
+          return;
+        }
+        var months = findArchiveMonths(summary, state.slug);
+        if (months && months.length) {
+          state.queue = months;
+        }
+        updateLoadMoreButton(state);
+      });
+    }
+  }
+
+  function fetchCategoryIndex(state) {
+    if (!state.slug) {
+      return Promise.reject(new Error('Missing category slug.'));
+    }
+    var path = '/data/categories/' + state.slug + '/index.json';
+    return fetchJson(path, { cache: 'no-store' });
+  }
+
+  function fetchArchiveBatch(slug, entry) {
+    var normalized = normalizeSlug(slug);
+    if (!normalized) {
+      return Promise.reject(new Error('Missing category slug.'));
+    }
+    var base = '/data/archive/' + normalized + '/' + entry.year + '/' + padMonth(entry.month);
+    return fetchJson(base + '.json', { cache: 'no-store' })
+      .catch(function () {
+        return fetchJson(base + '/index.json', { cache: 'no-store' });
+      });
+  }
+
+  function handleLoadMore(state) {
+    if (!state || state.isLoading) {
+      return;
+    }
+    if (!state.queue || !state.queue.length) {
+      setStatus(state.statusEl, 'No additional posts to load.');
+      updateLoadMoreButton(state);
+      return;
+    }
+    var next = state.queue.shift();
+    if (!next) {
+      updateLoadMoreButton(state);
+      return;
+    }
+    state.isLoading = true;
+    updateLoadMoreButton(state);
+    var label = monthLabel(next.year, next.month);
+    var hadError = false;
+    fetchArchiveBatch(state.slug, next)
+      .then(function (payload) {
+        var posts = extractPosts(payload);
+        var added = appendPosts(state, posts);
+        if (!added) {
+          showEmptyState(state.postList, 'No archived posts available for ' + (label || 'this month') + '.');
+          setStatus(state.statusEl, 'No archived posts found for ' + (label || 'this month') + '.');
+        } else {
+          setStatus(state.statusEl, 'Loaded ' + added + ' posts from ' + (label || 'the archive') + '.');
+        }
+      })
+      .catch(function (err) {
+        hadError = true;
+        console.warn('Archive load failed:', err);
+        setStatus(state.statusEl, 'Could not load more posts at this time.');
+      })
+      .then(function () {
+        state.isLoading = false;
+        updateLoadMoreButton(state);
+        if (!hadError && (!state.queue || !state.queue.length)) {
+          setStatus(state.statusEl, 'You have reached the end of the archive.');
+        }
+      });
+  }
+
+  function initCategoryFeed() {
+    var section = document.querySelector('[data-category-feed]');
+    if (!section) {
+      return;
+    }
+    var slug = readCategorySlug(section);
+    if (!slug) {
+      setStatus(document.querySelector('[data-load-more-status]'), 'Missing category identifier.');
+      return;
+    }
+    var postList = section.querySelector('[data-post-list]') || document.querySelector('[data-post-list]');
+    var statusEl = section.querySelector('[data-load-more-status]') || document.querySelector('[data-load-more-status]');
+    var button = section.querySelector('[data-load-more]') || document.querySelector('[data-load-more]');
+
+    categoryState = {
+      element: section,
+      slug: slug,
+      postList: postList,
+      statusEl: statusEl,
+      button: button,
+      queue: [],
+      isLoading: false,
+      deduper: new Deduper(),
+      initialised: false
+    };
+
+    if (categoryState.button) {
+      updateLoadMoreButton(categoryState);
+      categoryState.button.addEventListener('click', function (event) {
+        event.preventDefault();
+        handleLoadMore(categoryState);
+      });
+    }
+
+    setStatus(categoryState.statusEl, 'Loading posts…');
+    fetchCategoryIndex(categoryState)
+      .then(function (payload) {
+        handleCategoryPayload(categoryState, payload);
+      })
+      .catch(function (err) {
+        console.warn('Category feed load failed:', err);
+        showEmptyState(categoryState.postList, 'We could not load posts for this category.');
+        setStatus(categoryState.statusEl, 'We could not load posts for this category.');
+        if (categoryState.button) {
+          categoryState.button.disabled = true;
+          categoryState.button.setAttribute('aria-disabled', 'true');
+        }
+      });
+  }
+
+  ready(function () {
+    initMenu();
+    initCategoryFeed();
+  });
+})(typeof window !== 'undefined' ? window : this, typeof document !== 'undefined' ? document : null);

--- a/src/site/_includes/layouts/base.njk
+++ b/src/site/_includes/layouts/base.njk
@@ -51,7 +51,7 @@
       window.__AVENTUROO_BASE_PATH__ = "{{ basePath | default('') | escape }}";
     </script>
     <script src="{{ '/js/base-path.js' | url }}"></script>
-    <script src="{{ '/js/menu.js' | url }}"></script>
+    <script src="{{ '/assets/js/data-loader.js' | url }}" defer></script>
     <script src="{{ '/js/jquery.js' | url }}"></script>
     <script src="{{ '/js/jquery.migrate.js' | url }}"></script>
     <script src="{{ '/js/footer-latest.js' | url }}"></script>
@@ -66,8 +66,6 @@
     <script src="{{ '/js/data-loader.js' | url }}"></script>
     <script src="{{ '/js/e-magz.js' | url }}"></script>
     <script src="{{ '/js/best-of-week.js' | url }}"></script>
-    <script src="{{ '/js/category.js' | url }}"></script>
-    <script src="{{ '/js/pagination.js' | url }}"></script>
     <script src="{{ '/js/homepage-hot-news.js' | url }}"></script>
     <script src="{{ '/js/home-latest.js' | url }}"></script>
     <script src="{{ '/js/single.js' | url }}"></script>

--- a/src/site/_includes/partials/header.njk
+++ b/src/site/_includes/partials/header.njk
@@ -56,139 +56,142 @@
         <a href="#" data-toggle="sidebar" data-target="#sidebar"><i class="ion-ios-arrow-left"></i></a>
       </div>
       <div id="menu-list">
-        <ul class="nav-list">
-          <li class="for-tablet nav-title"><a>Menu</a></li>
-          <li class="for-tablet"><a href="{{ '/login.html' | url }}">Login</a></li>
-          <li class="for-tablet"><a href="{{ '/register.html' | url }}">Register</a></li>
-          <li><a href="{{ '/' | url }}">HOME</a></li>
+        <div data-category-menu></div>
+        <noscript>
+          <ul class="nav-list">
+            <li class="for-tablet nav-title"><a>Menu</a></li>
+            <li class="for-tablet"><a href="{{ '/login.html' | url }}">Login</a></li>
+            <li class="for-tablet"><a href="{{ '/register.html' | url }}">Register</a></li>
+            <li><a href="{{ '/' | url }}">HOME</a></li>
 
-          <li class="dropdown magz-dropdown">
-            <a href="{{ '/category.html' | url }}?cat=news">News <i class="ion-ios-arrow-right"></i></a>
-            <ul class="dropdown-menu">
-              <li><a href="{{ '/category.html' | url }}?cat=top-stories">Top Stories</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=politics">Politics</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=economy">Economy</a></li>
-              <li class="dropdown magz-dropdown">
-                <a href="{{ '/category.html' | url }}?cat=business-finance">Business &amp; Finance <i class="ion-ios-arrow-right"></i></a>
-                <ul class="dropdown-menu">
-                  <li><a href="{{ '/category.html' | url }}?cat=markets-economy">Markets &amp; Economy</a></li>
-                  <li><a href="{{ '/category.html' | url }}?cat=companies-startups">Companies &amp; Startups</a></li>
-                  <li><a href="{{ '/category.html' | url }}?cat=personal-finance">Personal Finance</a></li>
-                </ul>
-              </li>
-            </ul>
-          </li>
+            <li class="dropdown magz-dropdown">
+              <a href="{{ '/category.html' | url }}?cat=news">News <i class="ion-ios-arrow-right"></i></a>
+              <ul class="dropdown-menu">
+                <li><a href="{{ '/category.html' | url }}?cat=top-stories">Top Stories</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=politics">Politics</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=economy">Economy</a></li>
+                <li class="dropdown magz-dropdown">
+                  <a href="{{ '/category.html' | url }}?cat=business-finance">Business &amp; Finance <i class="ion-ios-arrow-right"></i></a>
+                  <ul class="dropdown-menu">
+                    <li><a href="{{ '/category.html' | url }}?cat=markets-economy">Markets &amp; Economy</a></li>
+                    <li><a href="{{ '/category.html' | url }}?cat=companies-startups">Companies &amp; Startups</a></li>
+                    <li><a href="{{ '/category.html' | url }}?cat=personal-finance">Personal Finance</a></li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
 
-          <li class="dropdown magz-dropdown magz-dropdown-megamenu"><a href="{{ '/category.html' | url }}?cat=tech-ai">Tech &amp; AI <i class="ion-ios-arrow-right"></i></a>
-            <div class="dropdown-menu megamenu">
-              <div class="megamenu-inner">
-                <div class="row">
-                  <div class="col-md-3">
-                    <h2 class="megamenu-title">AI &amp; BIG TECH</h2>
-                    <ul class="vertical-menu">
-                      <li><a href="{{ '/category.html' | url }}?cat=ai-news">AI News</a></li>
-                      <li><a href="{{ '/category.html' | url }}?cat=big-tech">Big Tech</a></li>
-                    </ul>
-                  </div>
-                  <div class="col-md-3">
-                    <h2 class="megamenu-title">INNOVATION</h2>
-                    <ul class="vertical-menu">
-                      <li><a href="{{ '/category.html' | url }}?cat=innovation-gadgets">Innovation &amp; Gadgets</a></li>
-                      <li><a href="{{ '/category.html' | url }}?cat=gaming-tech">Gaming Tech / AI Gaming</a></li>
-                    </ul>
-                  </div>
-                  <div class="col-md-3">
-                    <h2 class="megamenu-title">SECURITY</h2>
-                    <ul class="vertical-menu">
-                      <li><a href="{{ '/category.html' | url }}?cat=security-privacy">Security &amp; Privacy</a></li>
-                      <li><a href="{{ '/category.html' | url }}?cat=internet-platforms">Internet &amp; Platforms</a></li>
-                      <h2 class="megamenu-title">Creator</h2>
-                      <li><a href="{{ '/category.html' | url }}?cat=audio-creator">Audio &amp; Creator Tools</a></li>
-                    </ul>
-                  </div>
-                  <div class="col-md-3">
-                    <h2 class="megamenu-title">CRYPTO</h2>
-                    <ul class="vertical-menu">
-                      <li><a href="{{ '/category.html' | url }}?cat=bitcoin-majors">Bitcoin &amp; Majors</a></li>
-                      <li><a href="{{ '/category.html' | url }}?cat=altcoins-web3">Altcoins &amp; Web3</a></li>
-                      <li><a href="{{ '/category.html' | url }}?cat=regulation-security">Regulation &amp; Security</a></li>
-                      <li><a href="{{ '/category.html' | url }}?cat=guides">Guides Crypto</a></li>
-                    </ul>
+            <li class="dropdown magz-dropdown magz-dropdown-megamenu"><a href="{{ '/category.html' | url }}?cat=tech-ai">Tech &amp; AI <i class="ion-ios-arrow-right"></i></a>
+              <div class="dropdown-menu megamenu">
+                <div class="megamenu-inner">
+                  <div class="row">
+                    <div class="col-md-3">
+                      <h2 class="megamenu-title">AI &amp; BIG TECH</h2>
+                      <ul class="vertical-menu">
+                        <li><a href="{{ '/category.html' | url }}?cat=ai-news">AI News</a></li>
+                        <li><a href="{{ '/category.html' | url }}?cat=big-tech">Big Tech</a></li>
+                      </ul>
+                    </div>
+                    <div class="col-md-3">
+                      <h2 class="megamenu-title">INNOVATION</h2>
+                      <ul class="vertical-menu">
+                        <li><a href="{{ '/category.html' | url }}?cat=innovation-gadgets">Innovation &amp; Gadgets</a></li>
+                        <li><a href="{{ '/category.html' | url }}?cat=gaming-tech">Gaming Tech / AI Gaming</a></li>
+                      </ul>
+                    </div>
+                    <div class="col-md-3">
+                      <h2 class="megamenu-title">SECURITY</h2>
+                      <ul class="vertical-menu">
+                        <li><a href="{{ '/category.html' | url }}?cat=security-privacy">Security &amp; Privacy</a></li>
+                        <li><a href="{{ '/category.html' | url }}?cat=internet-platforms">Internet &amp; Platforms</a></li>
+                        <h2 class="megamenu-title">Creator</h2>
+                        <li><a href="{{ '/category.html' | url }}?cat=audio-creator">Audio &amp; Creator Tools</a></li>
+                      </ul>
+                    </div>
+                    <div class="col-md-3">
+                      <h2 class="megamenu-title">CRYPTO</h2>
+                      <ul class="vertical-menu">
+                        <li><a href="{{ '/category.html' | url }}?cat=bitcoin-majors">Bitcoin &amp; Majors</a></li>
+                        <li><a href="{{ '/category.html' | url }}?cat=altcoins-web3">Altcoins &amp; Web3</a></li>
+                        <li><a href="{{ '/category.html' | url }}?cat=regulation-security">Regulation &amp; Security</a></li>
+                        <li><a href="{{ '/category.html' | url }}?cat=guides">Guides Crypto</a></li>
+                      </ul>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </li>
+            </li>
 
-          <li class="dropdown magz-dropdown">
-            <a href="{{ '/category.html' | url }}?cat=entertainment">Entertainment <i class="ion-ios-arrow-right"></i></a>
-            <ul class="dropdown-menu">
-              <li><a href="{{ '/category.html' | url }}?cat=movies">Movies</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=tv-streaming">TV-Streaming</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=trailers">Trailers</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=cinematography">Cinematography</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=history-essays">History &amp; Essays</a></li>
-            </ul>
-          </li>
+            <li class="dropdown magz-dropdown">
+              <a href="{{ '/category.html' | url }}?cat=entertainment">Entertainment <i class="ion-ios-arrow-right"></i></a>
+              <ul class="dropdown-menu">
+                <li><a href="{{ '/category.html' | url }}?cat=movies">Movies</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=tv-streaming">TV-Streaming</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=trailers">Trailers</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=cinematography">Cinematography</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=history-essays">History &amp; Essays</a></li>
+              </ul>
+            </li>
 
-          <li class="dropdown magz-dropdown">
-            <a href="{{ '/category.html' | url }}?cat=lifestyle">Lifestyle <i class="ion-ios-arrow-right"></i></a>
-            <ul class="dropdown-menu">
-              <li><a href="{{ '/category.html' | url }}?cat=health">Health</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=beauty-style">Beauty &amp; Style</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=home-design">Home &amp; Design</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=inspiration">Inspiration</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=outdoor">Outdoor</a></li>
-              <li class="dropdown magz-dropdown">
-                <a href="{{ '/category.html' | url }}?cat=food-drink">Food &amp; Drink <i class="ion-ios-arrow-right"></i></a>
-                <ul class="dropdown-menu">
-                  <li><a href="{{ '/category.html' | url }}?cat=food">Food</a></li>
-                  <li><a href="{{ '/category.html' | url }}?cat=drink">Drink</a></li>
-                  <li><a href="{{ '/category.html' | url }}?cat=guides">Guides</a></li>
-                </ul>
-              </li>
-            </ul>
-          </li>
+            <li class="dropdown magz-dropdown">
+              <a href="{{ '/category.html' | url }}?cat=lifestyle">Lifestyle <i class="ion-ios-arrow-right"></i></a>
+              <ul class="dropdown-menu">
+                <li><a href="{{ '/category.html' | url }}?cat=health">Health</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=beauty-style">Beauty &amp; Style</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=home-design">Home &amp; Design</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=inspiration">Inspiration</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=outdoor">Outdoor</a></li>
+                <li class="dropdown magz-dropdown">
+                  <a href="{{ '/category.html' | url }}?cat=food-drink">Food &amp; Drink <i class="ion-ios-arrow-right"></i></a>
+                  <ul class="dropdown-menu">
+                    <li><a href="{{ '/category.html' | url }}?cat=food">Food</a></li>
+                    <li><a href="{{ '/category.html' | url }}?cat=drink">Drink</a></li>
+                    <li><a href="{{ '/category.html' | url }}?cat=guides">Guides</a></li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
 
-          <li class="dropdown magz-dropdown">
-            <a href="{{ '/category.html' | url }}?cat=travel">Travel <i class="ion-ios-arrow-right"></i></a>
-            <ul class="dropdown-menu">
-              <li><a href="{{ '/category.html' | url }}?cat=trip-ideas">Trip Ideas</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=destinations">Destinations</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=tips-planning">Tips &amp; Planning</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=stays-hotels">Stays (Hotels)</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=experiences">Experiences</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=transport">Transport</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=things-to-do">Things To Do</a></li>
-            </ul>
-          </li>
+            <li class="dropdown magz-dropdown">
+              <a href="{{ '/category.html' | url }}?cat=travel">Travel <i class="ion-ios-arrow-right"></i></a>
+              <ul class="dropdown-menu">
+                <li><a href="{{ '/category.html' | url }}?cat=trip-ideas">Trip Ideas</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=destinations">Destinations</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=tips-planning">Tips &amp; Planning</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=stays-hotels">Stays (Hotels)</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=experiences">Experiences</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=transport">Transport</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=things-to-do">Things To Do</a></li>
+              </ul>
+            </li>
 
-          <li class="dropdown magz-dropdown">
-            <a href="{{ '/category.html' | url }}?cat=culture-arts">Culture &amp; Arts <i class="ion-ios-arrow-right"></i></a>
-            <ul class="dropdown-menu">
-              <li><a href="{{ '/category.html' | url }}?cat=culture">Culture</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=arts">Arts</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=history">History</a></li>
-            </ul>
-          </li>
+            <li class="dropdown magz-dropdown">
+              <a href="{{ '/category.html' | url }}?cat=culture-arts">Culture &amp; Arts <i class="ion-ios-arrow-right"></i></a>
+              <ul class="dropdown-menu">
+                <li><a href="{{ '/category.html' | url }}?cat=culture">Culture</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=arts">Arts</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=history">History</a></li>
+              </ul>
+            </li>
 
-          <li class="dropdown magz-dropdown">
-            <a href="{{ '/category.html' | url }}?cat=shopping">Shopping <i class="ion-ios-arrow-right"></i></a>
-            <ul class="dropdown-menu">
-              <li><a href="{{ '/category.html' | url }}?cat=tech-deals">Tech Deals</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=subscriptions">Subscriptions</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=travel-deals">Travel Deals</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=vpn-security">VPN &amp; Security</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=marketplaces">Marketplaces</a></li>
-              <li><a href="{{ '/category.html' | url }}?cat=multi-merchant">Multi-merchant Networks</a></li>
-            </ul>
-          </li>
+            <li class="dropdown magz-dropdown">
+              <a href="{{ '/category.html' | url }}?cat=shopping">Shopping <i class="ion-ios-arrow-right"></i></a>
+              <ul class="dropdown-menu">
+                <li><a href="{{ '/category.html' | url }}?cat=tech-deals">Tech Deals</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=subscriptions">Subscriptions</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=travel-deals">Travel Deals</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=vpn-security">VPN &amp; Security</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=marketplaces">Marketplaces</a></li>
+                <li><a href="{{ '/category.html' | url }}?cat=multi-merchant">Multi-merchant Networks</a></li>
+              </ul>
+            </li>
 
-          <li><a href="{{ '/archive.html' | url }}">ARCHIVE</a></li>
+            <li><a href="{{ '/archive.html' | url }}">ARCHIVE</a></li>
 
-          <li><a href="{{ '/page.html' | url }}">About Us </a></li>
+            <li><a href="{{ '/page.html' | url }}">About Us </a></li>
 
-        </ul>
+          </ul>
+        </noscript>
       </div>
     </div>
   </nav>

--- a/src/site/category.njk
+++ b/src/site/category.njk
@@ -2,34 +2,33 @@
 layout: layouts/base.njk
 permalink: category.html
 ---
-<section class="category">
-		  <div class="container">
-		    <div class="row">
+<section class="category" data-category-feed data-category="{{ slug or '' }}">
+                  <div class="container">
+                    <div class="row">
 
-				
-		      <div class="col-md-8 text-left">
-		        <div class="row">
-		          <div class="col-md-12">        
-		            <ol class="breadcrumb">
-		              <li><a href="#">Home</a></li>
-		              <li class="active">Computer</li>
-		            </ol>
-		            <h3 class="page-title">Category: Computer</h3>
-		            <p class="page-subtitle">Showing all posts with category <i>Computer</i></p>
-		          </div>
-		        </div>
-		        <div class="line"></div>
-		        <div class="row">
-					
-					<div id="post-list" class="row"></div>
+
+                      <div class="col-md-8 text-left">
+                        <div class="row">
+                          <div class="col-md-12">
+                            <ol class="breadcrumb">
+                              <li><a href="{{ '/' | url }}">Home</a></li>
+                              <li class="active">{{ title or slug or 'Category' }}</li>
+                            </ol>
+                            <h3 class="page-title">Category: {{ title or slug or 'Category' }}</h3>
+                            <p class="page-subtitle">Showing all posts with category <i>{{ title or slug or 'Category' }}</i></p>
+                          </div>
+                        </div>
+                        <div class="line"></div>
+                        <div class="row">
+                                        <ul class="row list-unstyled" data-post-list></ul>
 
                           <div class="col-md-12 text-center">
-                            <ul id="pagination" class="pagination"></ul>
-                            <div id="pagination-info" class="pagination-help-text"></div>
+                            <p class="text-muted" data-load-more-status aria-live="polite"></p>
+                            <button type="button" class="btn btn-primary" data-load-more data-label="Load more" data-loading-label="Loading…">Load more</button>
                           </div>
-					
-		        </div>
-		      </div>
+
+                        </div>
+                      </div>
 				
                       <div class="col-md-4 sidebar">
                         <aside id="sidebar-top-ad">


### PR DESCRIPTION
## Summary
- create a client-side data loader that builds the nav menu, category feeds, and archive pagination via fetch APIs
- update header, base layout, and category templates to use the new loader attributes while removing redundant scripts
- document the required HTML scaffold for the loader in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d319e383e08333b81d27446285e0c1