### PR TITLE
Add validation step to autopost workflow

### DIFF
--- a/.github/workflows/autopost.yml
+++ b/.github/workflows/autopost.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build feeds
         run: python scripts/build_feeds.py
 
+      - name: Validate feeds
+        run: python scripts/validate_feeds.py
+
       - name: Upload autopost debug artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- run feed validation as part of the autopost workflow before publishing changes

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d323eb19a48333b04c59c8be82242c