### PR TITLE
Sort normalized URL query params and test hash stability

### DIFF
--- a/autopost/pull_news.py
+++ b/autopost/pull_news.py
@@ -360,6 +360,8 @@ def normalize_link(link: str) -> str:
     filtered_params = [
         (k, v) for k, v in query_params if not is_tracking_param(k)
     ]
+    if filtered_params:
+        filtered_params = sorted(filtered_params, key=lambda item: (item[0], item[1]))
     query = urlencode(filtered_params, doseq=True)
     normalized = urlunparse(
         parsed._replace(

--- a/tests/test_pull_news.py
+++ b/tests/test_pull_news.py
@@ -9,6 +9,15 @@ import xml.etree.ElementTree as ET
 from autopost import pull_news
 
 
+class LinkNormalizationTests(unittest.TestCase):
+    def test_link_hash_ignores_parameter_order(self):
+        url_a = "https://example.com/article?b=2&a=1"
+        url_b = "https://example.com/article?a=1&b=2"
+
+        self.assertEqual(pull_news.normalize_link(url_a), pull_news.normalize_link(url_b))
+        self.assertEqual(pull_news.link_hash(url_a), pull_news.link_hash(url_b))
+
+
 class ResolveCoverUrlTests(unittest.TestCase):
     def test_empty_cover_uses_fallback(self):
         fallback = pull_news.sanitize_img_url(pull_news.FALLBACK_COVER)


### PR DESCRIPTION
## Summary
- sort non-tracking URL query parameters before encoding during link normalization to ensure deterministic canonicalization
- add a unit test verifying link normalization and hashing produce consistent results regardless of parameter ordering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d335aa568083338d013368339d954c