### PR TITLE
Normalize default ports in link hashing

### DIFF
--- a/autopost/pull_news.py
+++ b/autopost/pull_news.py
@@ -340,9 +340,14 @@ def _normalized_netloc(parsed) -> str:
         if parsed.password:
             userinfo += f":{parsed.password}"
         userinfo += "@"
+    scheme = (parsed.scheme or "").lower()
     try:
         port = parsed.port
     except ValueError:
+        port = None
+    if port == 80 and scheme == "http":
+        port = None
+    elif port == 443 and scheme == "https":
         port = None
     port_str = f":{port}" if port else ""
     return f"{userinfo}{host}{port_str}"

--- a/tests/test_pull_news.py
+++ b/tests/test_pull_news.py
@@ -17,6 +17,20 @@ class LinkNormalizationTests(unittest.TestCase):
         self.assertEqual(pull_news.normalize_link(url_a), pull_news.normalize_link(url_b))
         self.assertEqual(pull_news.link_hash(url_a), pull_news.link_hash(url_b))
 
+    def test_link_hash_ignores_default_https_port(self):
+        url_a = "https://example.com/path"
+        url_b = "https://example.com:443/path"
+
+        self.assertEqual(pull_news.normalize_link(url_a), pull_news.normalize_link(url_b))
+        self.assertEqual(pull_news.link_hash(url_a), pull_news.link_hash(url_b))
+
+    def test_link_hash_ignores_default_http_port(self):
+        url_a = "http://example.com/path"
+        url_b = "http://example.com:80/path"
+
+        self.assertEqual(pull_news.normalize_link(url_a), pull_news.normalize_link(url_b))
+        self.assertEqual(pull_news.link_hash(url_a), pull_news.link_hash(url_b))
+
 
 class ResolveCoverUrlTests(unittest.TestCase):
     def test_empty_cover_uses_fallback(self):


### PR DESCRIPTION
## Summary
- update `_normalized_netloc` to drop default HTTP/HTTPS ports during normalization
- extend link hashing tests to cover equivalence of URLs with explicit default ports

## Testing
- pytest tests/test_pull_news.py

------
https://chatgpt.com/codex/tasks/task_e_68d3388b8ca88333ae68e61a0f98a730