### PR TITLE
Configure Netlify publish artifacts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,21 @@
 [build]
-  command = "npm run build"
+  command = "npm run build && if [ -d data ]; then mkdir -p _site/data && cp -R data/. _site/data/; fi && if [ -f _redirects ]; then cp _redirects _site/_redirects; fi && if [ -f _headers ]; then cp _headers _site/_headers; fi"
   publish = "_site"
+
+# Disable Netlify post processing minification so JSON payloads remain untouched.
+[build.processing]
+  skip_processing = false
+
+[build.processing.css]
+  bundle = false
+  minify = false
+
+[build.processing.js]
+  bundle = false
+  minify = false
+
+[build.processing.images]
+  compress = false
 
 [[headers]]
   for = "/archive/*"


### PR DESCRIPTION
## Summary
- extend the Netlify build command so the generated site copies the data directory and deploy metadata files into the publish folder
- disable Netlify post processing minification to avoid altering JSON payloads while keeping existing cache headers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3aba4d4dc8333b1465b7d6fb250b6