### PR TITLE
Standardize food-drink general feed and add category alias map

### DIFF
--- a/data/hot/category_aliases.json
+++ b/data/hot/category_aliases.json
@@ -1,0 +1,9 @@
+{
+  "standard_child": "general",
+  "aliases": {
+    "lifestyle/index": "lifestyle/general",
+    "crypto/index": "crypto/general",
+    "index/index": "index/general",
+    "food-drink/food-drink": "food-drink/general"
+  }
+}

--- a/data/hot/food-drink/general/index.json
+++ b/data/hot/food-drink/general/index.json
@@ -6,7 +6,7 @@
       "date": "2025-09-23",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/We-Tried-the-Papier-Stationery-Advent-Calendar-That-Sells-Out-Every-Year_IMG_5187_Katie-Bandurski-for-TOH_FT.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/we-tried-the-papier-stationery-advent-calendar-that-sells-out-every-year-2025-09-23/",
-      "excerpt": "This beauty comes with impressive contents—and a $175 price tag. Is it worth the hype?",
+      "excerpt": "This beauty comes with impressive contents\u2014and a $175 price tag. Is it worth the hype?",
       "source": "https://www.tasteofhome.com/article/papier-advent-calendar/"
     },
     {
@@ -24,7 +24,7 @@
       "date": "2025-09-22",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/25-del-ecomm-lead-thingseveryparentshouldhaveintheirkitchen-r1-v2-68d1a3dd7a895.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/the-parents-in-our-office-swear-by-these-kitchen-essentials-to-make-mealtime-easier-2025-09-22/",
-      "excerpt": "Editorial Business Manager Megan Belair reaches for this tool on the regular. She can open, pit, and slice an avocado with just one utensil—so she can keep up with demand from her 1½-year-old.",
+      "excerpt": "Editorial Business Manager Megan Belair reaches for this tool on the regular. She can open, pit, and slice an avocado with just one utensil\u2014so she can keep up with demand from her 1\u00bd-year-old.",
       "source": "https://www.delish.com/kitchen-tools/cookware-reviews/g66335165/parent-approved-kitchen-essentials-kids-mealtime/"
     },
     {
@@ -33,7 +33,7 @@
       "date": "2025-09-22",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/Pickle-Canoes_EXPS_RC25_279193_DR_04_15_06b.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/pickle-canoes-2025-09-22/",
-      "excerpt": "I came up with this recipe when I was looking for a snack in my grandparents' fridge and saw these ingredients. Everyone in my family wanted to try my creation and said it was amazing. —Donnie Voss, Savage, Minnesota",
+      "excerpt": "I came up with this recipe when I was looking for a snack in my grandparents' fridge and saw these ingredients. Everyone in my family wanted to try my creation and said it was amazing. \u2014Donnie Voss, Savage, Minnesota",
       "source": "https://www.tasteofhome.com/recipes/pickle-canoes/"
     },
     {
@@ -60,7 +60,7 @@
       "date": "2025-09-22",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/Hot-Apricot-Chai-Cocktail_EXPS_RC25_279169_DR_04_17_02b.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/hot-apricot-chai-cocktail-2025-09-22/",
-      "excerpt": "This lovely wintertime cocktail is a hit with my friends for its rich flavor and easy prep. I like to garnish it with a slice of orange. —Aysha Schurman, Ammon, Idaho",
+      "excerpt": "This lovely wintertime cocktail is a hit with my friends for its rich flavor and easy prep. I like to garnish it with a slice of orange. \u2014Aysha Schurman, Ammon, Idaho",
       "source": "https://www.tasteofhome.com/recipes/hot-apricot-chai-cocktail/"
     },
     {
@@ -69,12 +69,12 @@
       "date": "2025-09-22",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/gyros-smash-tacos-socialindex-web-aa-099-del079925-688a33a211867.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/celebrate-your-most-stylish-indecisive-friends-with-these-16-libra-inspired-recipes-2025-09-22/",
-      "excerpt": "Instead of stressing about what to have for dinner , just mash two favorites together like we did for this lasagna-enchilada hybrid! Everything you’d usually find between the noodle layers in lasagna —saucy beef Bolognese and herby ricotta —rolled into flour tortillas and topp…",
+      "excerpt": "Instead of stressing about what to have for dinner , just mash two favorites together like we did for this lasagna-enchilada hybrid! Everything you\u2019d usually find between the noodle layers in lasagna \u2014saucy beef Bolognese and herby ricotta \u2014rolled into flour tortillas and topp\u2026",
       "source": "https://www.delish.com/cooking/recipe-ideas/g68005966/best-libra-inspired-recipes/"
     },
     {
       "slug": "benson-boone-s-favorite-food-is-one-of-his-mom-s-recipes-2025-09-22",
-      "title": "Benson Boone’s Favorite Food Is One of His Mom’s Recipes",
+      "title": "Benson Boone\u2019s Favorite Food Is One of His Mom\u2019s Recipes",
       "date": "2025-09-22",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/07/Benson-Boone-Favorite-Food_GettyImages-2220317260_FT.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/benson-boone-s-favorite-food-is-one-of-his-mom-s-recipes-2025-09-22/",
@@ -87,7 +87,7 @@
       "date": "2025-09-22",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/apple-tart-index-68d1ae943e79c.jpeg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/apple-tart-2025-09-22/",
-      "excerpt": "I'll be honest: this recipe kept me up at night. An apple tart is the pinnacle of fall desserts to me, so when I was developing this recipe, I tossed and turned trying to figure out how to make a gorgeous but easy apple tart that's worthy of your Thanksgiving table (or any fal…",
+      "excerpt": "I'll be honest: this recipe kept me up at night. An apple tart is the pinnacle of fall desserts to me, so when I was developing this recipe, I tossed and turned trying to figure out how to make a gorgeous but easy apple tart that's worthy of your Thanksgiving table (or any fal\u2026",
       "source": "https://www.delish.com/cooking/recipe-ideas/a23364812/apple-tart-recipe/"
     },
     {
@@ -96,17 +96,35 @@
       "date": "2025-09-21",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/subway-usa-royalty-free-image-1758382583.pjpeg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/subway-bulks-up-with-a-delicious-high-protein-menu-upgrade-2025-09-21/",
-      "excerpt": "Protein is having a main character year. There’s protein popcorn , protein sparkling drinks at warehouse clubs, protein cold foam , and now Subway is giving lunch the gym rat treatment.",
+      "excerpt": "Protein is having a main character year. There\u2019s protein popcorn , protein sparkling drinks at warehouse clubs, protein cold foam , and now Subway is giving lunch the gym rat treatment.",
       "source": "https://www.delish.com/food-news/a67978234/subway-fresh-fit-protein-sandwiches-new-menu/"
     },
     {
       "slug": "doritos-drops-limited-retro-stranger-things-flavor-fans-say-keep-it-forever-2025-09-21",
-      "title": "Doritos Drops Limited Retro ‘Stranger Things’ Flavor & Fans Say Keep It Forever",
+      "title": "Doritos Drops Limited Retro \u2018Stranger Things\u2019 Flavor & Fans Say Keep It Forever",
       "date": "2025-09-21",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/screenshot-2025-09-19-at-9-44-30-pm-68ce09a0cc6d3.png",
       "canonical": "https://archive.aventuroo.com/food-drink/general/doritos-drops-limited-retro-stranger-things-flavor-fans-say-keep-it-forever-2025-09-21/",
-      "excerpt": "Doritos rewound the VCR for their newest drop on shelves now: the ‘Stranger Pizza x Cool Ranch’ Collisions flavor. It lands in retro '80s packaging, right alongside Stranger Things -style throwback bags for the core lineup. It’s a neat wink to Cool Ranch’s actual ’80s debut, t…",
+      "excerpt": "Doritos rewound the VCR for their newest drop on shelves now: the \u2018Stranger Pizza x Cool Ranch\u2019 Collisions flavor. It lands in retro '80s packaging, right alongside Stranger Things -style throwback bags for the core lineup. It\u2019s a neat wink to Cool Ranch\u2019s actual \u201980s debut, t\u2026",
       "source": "https://www.delish.com/food-news/a67972710/doritos-retro-stranger-things-pizza-cool-ranch/"
+    },
+    {
+      "slug": "public-health-alert-issued-for-a-seasonal-trader-joe-s-ready-to-eat-favorite-2025-09-20",
+      "title": "Public Health Alert Issued For A Seasonal Trader Joe's Ready-to-Eat Favorite",
+      "date": "2025-09-20",
+      "cover": "https://hips.hearstapps.com/hmg-prod/images/close-up-of-trader-joes-grocery-store-sign-on-building-news-photo-1758391535.pjpeg",
+      "canonical": "https://archive.aventuroo.com/food-drink/food-drink/public-health-alert-issued-for-a-seasonal-trader-joe-s-ready-to-eat-favorite-2025-09-20/",
+      "excerpt": "The U.S. Department of Agriculture\u2019s Food Safety and Inspection Service (FSIS) issued a public health alert for a ready-to-eat turkey wrap sold at Trader Joe\u2019s due to possible Listeria monocytogenes contamination.",
+      "source": "https://www.delish.com/food-news/a67979954/trader-joes-fsis-public-health-alert-turkey-gobbler-wrap/"
+    },
+    {
+      "slug": "psa-this-nationwide-smoked-fish-recall-is-one-you-shouldn-t-ignore-2025-09-20",
+      "title": "PSA: This Nationwide Smoked Fish Recall Is One You Shouldn't Ignore",
+      "date": "2025-09-20",
+      "cover": "https://hips.hearstapps.com/hmg-prod/images/close-up-of-rolls-of-smoked-salmon-on-a-gray-royalty-free-image-1758327587.pjpeg",
+      "canonical": "https://archive.aventuroo.com/food-drink/food-drink/psa-this-nationwide-smoked-fish-recall-is-one-you-shouldn-t-ignore-2025-09-20/",
+      "excerpt": "Smoked fish and schmear on a bagel kind of morning? Hit pause. Haifa Smoked Fish has recalled two cold-smoked items due to potential Listeria contamination, and the affected lots were distributed to stores and distributors across the U.S.",
+      "source": "https://www.delish.com/food-news/a67972418/smoked-fish-recall-haifa-salmon-sea-bass-listeria/"
     },
     {
       "slug": "mushroom-gravy-2025-09-19",
@@ -123,12 +141,12 @@
       "date": "2025-09-19",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/Japanese-Crab-and-Avocado-Salad_EXPS_RC25_278911_DR_04_15_08b.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/japanese-crab-and-avocado-salad-2025-09-19/",
-      "excerpt": "It can be a challenge to find winter holiday recipes that are suited to warmer climates. This luxurious Asian-inspired crab salad fills the bill with its festive colors and flavors. —Laura Wilhelm, West Hollywood, California",
+      "excerpt": "It can be a challenge to find winter holiday recipes that are suited to warmer climates. This luxurious Asian-inspired crab salad fills the bill with its festive colors and flavors. \u2014Laura Wilhelm, West Hollywood, California",
       "source": "https://www.tasteofhome.com/recipes/japanese-crab-and-avocado-salad/"
     },
     {
       "slug": "is-aldi-s-diet-cola-really-a-dupe-for-mcdonald-s-diet-coke-2025-09-19",
-      "title": "Is Aldi’s Diet Cola Really a Dupe for McDonald’s Diet Coke?",
+      "title": "Is Aldi\u2019s Diet Cola Really a Dupe for McDonald\u2019s Diet Coke?",
       "date": "2025-09-19",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/06/Is-Aldis-Diet-Cola-Really-a-Dupe-for-McDonalds-Diet-Coke_GettyImages-2151954706_Hayley-Schueneman-for-Taste-of-home_DKedit_FT.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/is-aldi-s-diet-cola-really-a-dupe-for-mcdonald-s-diet-coke-2025-09-19/",
@@ -141,7 +159,7 @@
       "date": "2025-09-19",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/Crispy-Party-Bites-_EXPS_RC25_279236_DR_04_17_06b.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/crispy-party-bites-2025-09-19/",
-      "excerpt": "These are so quick to make and are great as a bite-sized appetizer. Throughout the years, I have substituted different meats, toppings and cheese, and it's always a favorite of guests. —Kristie Schley, Pasadena, Maryland",
+      "excerpt": "These are so quick to make and are great as a bite-sized appetizer. Throughout the years, I have substituted different meats, toppings and cheese, and it's always a favorite of guests. \u2014Kristie Schley, Pasadena, Maryland",
       "source": "https://www.tasteofhome.com/recipes/crispy-party-bites/"
     },
     {
@@ -150,12 +168,57 @@
       "date": "2025-09-19",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/Cheesy-Bruschetta-Dip_EXPS_RC25_279226_DR_04_16_05b.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/cheesy-bruschetta-dip-2025-09-19/",
-      "excerpt": "This creamy, flavorful dip comes together quickly and is a real crowd-pleaser. It is a delicious complement to a meal or a fun appetizer to serve at a party. —Theresa Ravencraft, Marysville, Ohio",
+      "excerpt": "This creamy, flavorful dip comes together quickly and is a real crowd-pleaser. It is a delicious complement to a meal or a fun appetizer to serve at a party. \u2014Theresa Ravencraft, Marysville, Ohio",
       "source": "https://www.tasteofhome.com/recipes/cheesy-bruschetta-dip/"
     },
     {
+      "slug": "white-cheddar-vs-cheddar-what-s-the-difference-2025-09-19",
+      "title": "White Cheddar vs. Cheddar: What\u2019s the Difference?",
+      "date": "2025-09-19",
+      "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/White-Cheddar-vs-Cheddar-Whats-The-Difference_GettyImages-136222393_FT.jpg",
+      "canonical": "https://archive.aventuroo.com/food-drink/food-drink/white-cheddar-vs-cheddar-what-s-the-difference-2025-09-19/",
+      "excerpt": "It's quite simple, really.",
+      "source": "https://www.tasteofhome.com/article/white-cheddar-vs-cheddar-difference/"
+    },
+    {
+      "slug": "the-lenox-spice-village-christmas-collection-is-here-2025-09-19",
+      "title": "The Lenox Spice Village Christmas Collection Is Here!",
+      "date": "2025-09-19",
+      "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/The-Lenox-Spice-Village-Christmas-Collection-Is-Here_via-lenox.com_FT.jpg",
+      "canonical": "https://archive.aventuroo.com/food-drink/food-drink/the-lenox-spice-village-christmas-collection-is-here-2025-09-19/",
+      "excerpt": "We're obsessed with the train server.",
+      "source": "https://www.tasteofhome.com/article/lenox-spice-village-christmas/"
+    },
+    {
+      "slug": "hot-honey-2025-09-19",
+      "title": "Hot Honey",
+      "date": "2025-09-19",
+      "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/EXPS_TOHD25_280836_SarahTramonte_4.jpg",
+      "canonical": "https://archive.aventuroo.com/food-drink/food-drink/hot-honey-2025-09-19/",
+      "excerpt": "When you keep a jar of hot honey in your pantry, suddenly every charcuterie board, brunch plate and late-night snack becomes a masterpiece.",
+      "source": "https://www.tasteofhome.com/recipes/hot-honey-recipe/"
+    },
+    {
+      "slug": "elise-jesse-s-white-chicken-chili-nachos-2025-09-19",
+      "title": "Elise Jesse\u2019s White Chicken Chili Nachos",
+      "date": "2025-09-19",
+      "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/EXPS_TOHCR25_280996_EJ_0908_1.jpg",
+      "canonical": "https://archive.aventuroo.com/food-drink/food-drink/elise-jesse-s-white-chicken-chili-nachos-2025-09-19/",
+      "excerpt": "Get ready to meet your new game-day obsession! These white chicken chili nachos are fully loaded and capture everything you love about the cozy, slow-simmered flavor of white chicken chili, but in a convenient nacho form. The chili is piled high on crispy tortilla chips, smoth\u2026",
+      "source": "https://www.tasteofhome.com/recipes/elise-jesse-white-chicken-chili-nachos/"
+    },
+    {
+      "slug": "4-ways-to-increase-your-tolerance-of-spicy-foods-2025-09-19",
+      "title": "4 Ways to Increase Your Tolerance of Spicy Foods",
+      "date": "2025-09-19",
+      "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/4-Ways-to-Increase-Your-Tolerance-of-Spicy-Foods_Chili-Crunch-Drip-2_Courtesy-A-Sha-Foods_FT.jpg",
+      "canonical": "https://archive.aventuroo.com/food-drink/food-drink/4-ways-to-increase-your-tolerance-of-spicy-foods-2025-09-19/",
+      "excerpt": "The days of avoiding that chile pepper on the menu are over.",
+      "source": "https://www.tasteofhome.com/article/spicy-food-tolerance-tips/"
+    },
+    {
       "slug": "the-stanley-cross-bottle-is-here-and-we-re-obsessed-with-the-dazzling-midnight-glitz-hue-2025-09-18",
-      "title": "The Stanley Cross Bottle Is Here—And We’re Obsessed With the Dazzling Midnight Glitz Hue",
+      "title": "The Stanley Cross Bottle Is Here\u2014And We\u2019re Obsessed With the Dazzling Midnight Glitz Hue",
       "date": "2025-09-18",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/The-Stanley-Cross-Bottle-Is-Here_via-stanley1913.com_GSedit_FT.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/the-stanley-cross-bottle-is-here-and-we-re-obsessed-with-the-dazzling-midnight-glitz-hue-2025-09-18/",
@@ -177,7 +240,7 @@
       "date": "2025-09-18",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/Orange-Snow-Balls_EXPS_RC25_279177_DR_04_15_03b.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/orange-snow-balls-2025-09-18/",
-      "excerpt": "These snow balls are perfectly sweet with just a hint of tart orange flavor. Everyone loves them, and I always get recipe requests when I bring them to a party. —Brooke Wofford, Travelers Rest, South Carolina",
+      "excerpt": "These snow balls are perfectly sweet with just a hint of tart orange flavor. Everyone loves them, and I always get recipe requests when I bring them to a party. \u2014Brooke Wofford, Travelers Rest, South Carolina",
       "source": "https://www.tasteofhome.com/recipes/orange-snow-balls/"
     },
     {
@@ -186,7 +249,7 @@
       "date": "2025-09-18",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/Muffaletta-Dip_EXPS_RC25_279219_DR_04_16_03b.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/muffaletta-dip-2025-09-18/",
-      "excerpt": "I love everything about a Muffaletta sandwich, so I just had to make it into a dip. It makes for a great party appetizer! —Courtney Stultz, Weir, Kansas",
+      "excerpt": "I love everything about a Muffaletta sandwich, so I just had to make it into a dip. It makes for a great party appetizer! \u2014Courtney Stultz, Weir, Kansas",
       "source": "https://www.tasteofhome.com/recipes/muffaletta-dip/"
     },
     {
@@ -195,7 +258,7 @@
       "date": "2025-09-18",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/Guava-Margaritas_EXPS_RC25_279000_DR_04_16_07b.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/guava-margaritas-2025-09-18/",
-      "excerpt": "While visiting family, I tasted a guava margarita and fell in love with the tropical flavors. I rushed home to create my own version! —Renee Page, Rochelle, Illinois",
+      "excerpt": "While visiting family, I tasted a guava margarita and fell in love with the tropical flavors. I rushed home to create my own version! \u2014Renee Page, Rochelle, Illinois",
       "source": "https://www.tasteofhome.com/recipes/guava-margaritas/"
     },
     {
@@ -208,6 +271,33 @@
       "source": "https://www.tasteofhome.com/recipes/bacon-cheeseburger-pizza/"
     },
     {
+      "slug": "warning-your-pumpkin-spice-latte-could-be-dangerous-for-your-pets-2025-09-18",
+      "title": "Warning\u2014Your Pumpkin Spice Latte Could Be Dangerous For Your Pets",
+      "date": "2025-09-18",
+      "cover": "https://hips.hearstapps.com/hmg-prod/images/pumpkin-spice-latte-ingredients-royalty-free-image-1758136047.pjpeg",
+      "canonical": "https://archive.aventuroo.com/food-drink/food-drink/warning-your-pumpkin-spice-latte-could-be-dangerous-for-your-pets-2025-09-18/",
+      "excerpt": "You likely don't think twice when ordering your fall-favorite pumpkin spice latte or whipping one up at home. But if you have furry friends, you might want to think twice before getting too close to man's best friend with a drink in hand.",
+      "source": "https://www.delish.com/food/a66419331/pumpkin-spice-latte-pet-safety-vet-warning/"
+    },
+    {
+      "slug": "the-6-most-caffeinated-drinks-at-starbucks-ranked-2025-09-18",
+      "title": "The 6 Most Caffeinated Drinks At Starbucks, Ranked",
+      "date": "2025-09-18",
+      "cover": "https://hips.hearstapps.com/hmg-prod/images/starbucks-logo-is-seen-on-a-coffee-cup-in-this-illustration-news-photo-1758137714.pjpeg",
+      "canonical": "https://archive.aventuroo.com/food-drink/food-drink/the-6-most-caffeinated-drinks-at-starbucks-ranked-2025-09-18/",
+      "excerpt": "I'd like to think of myself as a naturally responsible, fully functioning adult with excellent time management skills, the patience of Mother Teresa, and a pristine color-coded calendar that ensures I'm never late. The reality? I need a cup of coffee (or six) every morning to \u2026",
+      "source": "https://www.delish.com/food-news/a66028227/most-caffeinated-starbucks-drinks-ranked/"
+    },
+    {
+      "slug": "apple-bottoms-just-made-jeans-with-a-seltzer-pocket-i-m-getting-low-2025-09-18",
+      "title": "Apple Bottoms Just Made Jeans With A Seltzer Pocket & I'm Getting Low",
+      "date": "2025-09-18",
+      "cover": "https://hips.hearstapps.com/hmg-prod/images/lead-kv-jeans-68c9b312023e9.jpg",
+      "canonical": "https://archive.aventuroo.com/food-drink/food-drink/apple-bottoms-just-made-jeans-with-a-seltzer-pocket-i-m-getting-low-2025-09-18/",
+      "excerpt": "Paging all millennials! Our favorite Band-Aid-sporting rapper launched the iconic Y2K Apple Bottom jeans back in 2002, which became so popular that they inspired a hit song by Flo Rida. Now they are back and better than ever: Apple Bottoms x bubly sparkling water. The two bran\u2026",
+      "source": "https://www.delish.com/food-news/a66126229/apple-bottoms-bubly-apple-release/"
+    },
+    {
       "slug": "vegan-chili-2025-09-17",
       "title": "Vegan Chili",
       "date": "2025-09-17",
@@ -218,11 +308,11 @@
     },
     {
       "slug": "popeyes-teamed-up-with-hot-ones-to-drop-its-spiciest-sauce-ever-and-i-tried-way-too-much-2025-09-17",
-      "title": "Popeyes Teamed Up With 'Hot Ones' To Drop Its Spiciest Sauce Ever—And I Tried Way Too Much",
+      "title": "Popeyes Teamed Up With 'Hot Ones' To Drop Its Spiciest Sauce Ever\u2014And I Tried Way Too Much",
       "date": "2025-09-17",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/img-7122-jpg-68c9a17458178.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/popeyes-teamed-up-with-hot-ones-to-drop-its-spiciest-sauce-ever-and-i-tried-way-too-much-2025-09-17/",
-      "excerpt": "By now, it's possible you've heard about Popeyes teaming up with the YouTube series Hot Ones to debut a limited-edition menu, which naturally features The Last Dab. The menu, which marks the first-of-its-kind collaboration with the show, includes items with varying spice level…",
+      "excerpt": "By now, it's possible you've heard about Popeyes teaming up with the YouTube series Hot Ones to debut a limited-edition menu, which naturally features The Last Dab. The menu, which marks the first-of-its-kind collaboration with the show, includes items with varying spice level\u2026",
       "source": "https://www.delish.com/food-news/a66126857/popeyes-hot-ones-review/"
     },
     {
@@ -231,21 +321,21 @@
       "date": "2025-09-17",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/female-hands-mixing-various-vegetable-in-wooden-royalty-free-image-1758127634.pjpeg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/nearly-50-000-units-of-popular-salad-dressing-recalled-for-undeclared-allergens-2025-09-17/",
-      "excerpt": "A Class I recall has been issued for nearly 50,000 units of honey balsamic salad dressing due to the presence of undeclared allergens. The recall, initiated by the manufacturer, began after it was discovered that the affected product contained Asian Sesame Ginger dressing rath…",
+      "excerpt": "A Class I recall has been issued for nearly 50,000 units of honey balsamic salad dressing due to the presence of undeclared allergens. The recall, initiated by the manufacturer, began after it was discovered that the affected product contained Asian Sesame Ginger dressing rath\u2026",
       "source": "https://www.delish.com/food-news/a66140112/honey-balsamic-salad-dressing-recall-latitude-36/"
     },
     {
       "slug": "i-tried-trader-joe-s-costco-pumpkin-muffins-side-by-side-here-s-the-winner-2025-09-17",
-      "title": "I Tried Trader Joe’s & Costco Pumpkin Muffins Side By Side—Here’s The Winner",
+      "title": "I Tried Trader Joe\u2019s & Costco Pumpkin Muffins Side By Side\u2014Here\u2019s The Winner",
       "date": "2025-09-17",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/img-7872-68c9de977431d.jpeg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/i-tried-trader-joe-s-costco-pumpkin-muffins-side-by-side-here-s-the-winner-2025-09-17/",
-      "excerpt": "Pumpkin spice season is in full swing, which means you can find our favorite fall flavor in everything from lattes to cheese . One of the most common iterations is the humble pumpkin muffin. You can make a recipe from scratch or with a pre-made mix, but nearly every cafe and g…",
+      "excerpt": "Pumpkin spice season is in full swing, which means you can find our favorite fall flavor in everything from lattes to cheese . One of the most common iterations is the humble pumpkin muffin. You can make a recipe from scratch or with a pre-made mix, but nearly every cafe and g\u2026",
       "source": "https://www.delish.com/food/a66131127/trader-joes-vs-costco-pumpkin-muffin-review/"
     },
     {
       "slug": "i-tried-milk-bar-s-tomato-mayo-cake-sandwich-we-need-to-talk-about-it-2025-09-17",
-      "title": "I Tried Milk Bar's Tomato & Mayo Cake Sandwich—We NEED To Talk About It",
+      "title": "I Tried Milk Bar's Tomato & Mayo Cake Sandwich\u2014We NEED To Talk About It",
       "date": "2025-09-17",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/hellmans-sweet-sandwich-68cae110e2a03.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/i-tried-milk-bar-s-tomato-mayo-cake-sandwich-we-need-to-talk-about-it-2025-09-17/",
@@ -258,7 +348,7 @@
       "date": "2025-09-17",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/delish-190625-apple-pancakes-0117-landscape-pf-1561753354.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/apple-pancakes-2025-09-17/",
-      "excerpt": "Picture a perfect cozy fall breakfast : Waking up without an alarm to the warming smells of cinnamon and apples wafting out of the kitchen, and finding a fresh stack of fluffy pancakes ready to be devoured. That’s enough even to get me out from under the blankets on a cool fal…",
+      "excerpt": "Picture a perfect cozy fall breakfast : Waking up without an alarm to the warming smells of cinnamon and apples wafting out of the kitchen, and finding a fresh stack of fluffy pancakes ready to be devoured. That\u2019s enough even to get me out from under the blankets on a cool fal\u2026",
       "source": "https://www.delish.com/cooking/recipe-ideas/a28186318/easy-apple-pancakes-recipe/"
     },
     {
@@ -281,25 +371,25 @@
     },
     {
       "slug": "tyler-smith-s-french-onion-sliders-2025-09-16",
-      "title": "Tyler Smith’s French Onion Sliders",
+      "title": "Tyler Smith\u2019s French Onion Sliders",
       "date": "2025-09-16",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/EXPS_TOHCR25_281011_TS_0909_1.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/tyler-smith-s-french-onion-sliders-2025-09-16/",
-      "excerpt": "These French onion cheeseburger sliders are the ultimate bite-sized indulgence. Juicy beef patties are topped with caramelized onions and melted cheese, all tucked into soft slider buns for a savory, melty twist on a classic. Perfect for game day parties or anytime you’re crav…",
+      "excerpt": "These French onion cheeseburger sliders are the ultimate bite-sized indulgence. Juicy beef patties are topped with caramelized onions and melted cheese, all tucked into soft slider buns for a savory, melty twist on a classic. Perfect for game day parties or anytime you\u2019re crav\u2026",
       "source": "https://www.tasteofhome.com/recipes/tyler-smith-french-onion-sliders/"
     },
     {
       "slug": "this-is-the-most-popular-soup-in-the-u-s-right-now-and-it-s-a-fall-classic-2025-09-16",
-      "title": "This Is The Most Popular Soup In The U.S. Right Now—And It's A Fall Classic",
+      "title": "This Is The Most Popular Soup In The U.S. Right Now\u2014And It's A Fall Classic",
       "date": "2025-09-16",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/bowl-filled-with-a-creamy-carrot-potato-soup-royalty-free-image-1758052651.pjpeg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/this-is-the-most-popular-soup-in-the-u-s-right-now-and-it-s-a-fall-classic-2025-09-16/",
-      "excerpt": "I am the first to admit: the end-of-summer blues are real. The days are shorter, the weather's cooler, and I've already been hit with my first fall cold. However, there is one silver lining that makes the seasonal shift actually worth it—and no, it's not the PSL. It's finally …",
+      "excerpt": "I am the first to admit: the end-of-summer blues are real. The days are shorter, the weather's cooler, and I've already been hit with my first fall cold. However, there is one silver lining that makes the seasonal shift actually worth it\u2014and no, it's not the PSL. It's finally \u2026",
       "source": "https://www.delish.com/food-news/a66128313/most-popular-soup-us-fall-2025/"
     },
     {
       "slug": "this-is-margot-robbie-s-go-to-breakfast-order-2025-09-16",
-      "title": "This Is Margot Robbie’s Go-To Breakfast Order",
+      "title": "This Is Margot Robbie\u2019s Go-To Breakfast Order",
       "date": "2025-09-16",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/06/This-Is-What-Margot-Robbie-Eats-for-Breakfast-Every-Day_GettyImages-2148569667_DKedit_FT.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/this-is-margot-robbie-s-go-to-breakfast-order-2025-09-16/",
@@ -312,16 +402,16 @@
       "date": "2025-09-16",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/candied-bacon-smokies-index-web-178-rv-del089925-68bef78c5fbd9.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/these-68-fall-appetizers-are-perfect-for-tailgates-holidays-cozy-nights-in-2025-09-16/",
-      "excerpt": "These sweet potato bites have a crunchy, herbaceous crust, with a sweet, silky inside that, when topped with a light drizzle of honey, will have you craving them again and again. Once you bite through the crust, the sweet potato mixes with that melted, nutty Gruyère for a drea…",
+      "excerpt": "These sweet potato bites have a crunchy, herbaceous crust, with a sweet, silky inside that, when topped with a light drizzle of honey, will have you craving them again and again. Once you bite through the crust, the sweet potato mixes with that melted, nutty Gruy\u00e8re for a drea\u2026",
       "source": "https://www.delish.com/cooking/recipe-ideas/g66071050/best-fall-appetizers/"
     },
     {
       "slug": "tam-to-s-one-pot-tomato-salmon-2025-09-16",
-      "title": "Tam To’s One-Pot Tomato Salmon",
+      "title": "Tam To\u2019s One-Pot Tomato Salmon",
       "date": "2025-09-16",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/EXPS_TOHCR25_280994_TT_0908_2.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/tam-to-s-one-pot-tomato-salmon-2025-09-16/",
-      "excerpt": "This one-pot tomato salmon recipe is a fresh spin on the classic Vietnamese dish of stuffed tofu in tomato sauce. The salmon is seared and cooked to tender perfection in a bright tomato sauce that's bursting with umami flavor from fish sauce. Serve it over rice or pasta, or en…",
+      "excerpt": "This one-pot tomato salmon recipe is a fresh spin on the classic Vietnamese dish of stuffed tofu in tomato sauce. The salmon is seared and cooked to tender perfection in a bright tomato sauce that's bursting with umami flavor from fish sauce. Serve it over rice or pasta, or en\u2026",
       "source": "https://www.tasteofhome.com/recipes/tam-to-one-pot-tomato-salmon/"
     },
     {
@@ -330,7 +420,7 @@
       "date": "2025-09-16",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/sweet-potato-fries-and-potato-chips-royalty-free-image-1758041086.pjpeg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/sweet-potato-fries-vs-regular-fries-experts-reveal-the-healthier-choice-2025-09-16/",
-      "excerpt": "Let’s be honest, few things in life are as satisfying as a heaping plate of hot, crispy fries . But a question has divided households and diners for years: When the waiter asks if you want to upgrade to sweet potato fries , should you? We’ve been led to believe that swapping r…",
+      "excerpt": "Let\u2019s be honest, few things in life are as satisfying as a heaping plate of hot, crispy fries . But a question has divided households and diners for years: When the waiter asks if you want to upgrade to sweet potato fries , should you? We\u2019ve been led to believe that swapping r\u2026",
       "source": "https://www.delish.com/food/a66125389/sweet-potato-fries-vs-regular-fries-nutrition/"
     },
     {
@@ -339,7 +429,7 @@
       "date": "2025-09-16",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/546524053-1307014744121666-6572939037030112436-n-68c9d0367fa93.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/stanley-s-new-halloween-collection-is-the-ghoulest-one-yet-2025-09-16/",
-      "excerpt": "Peak Stanley Mania may be behind us, but the brand keeps coming out with new designs that convince us to grow our collections. The Mesa Rose drop from earlier this year practically broke the internet, and we're anticipating a second wave of Wicked cups ahead of the movie's par…",
+      "excerpt": "Peak Stanley Mania may be behind us, but the brand keeps coming out with new designs that convince us to grow our collections. The Mesa Rose drop from earlier this year practically broke the internet, and we're anticipating a second wave of Wicked cups ahead of the movie's par\u2026",
       "source": "https://www.delish.com/food-news/a66130391/stanley-halloween-collection-2025/"
     },
     {
@@ -362,11 +452,11 @@
     },
     {
       "slug": "national-cheeseburger-day-is-here-celebrate-with-these-juicy-deals-2025-09-16",
-      "title": "National Cheeseburger Day Is Here—Celebrate With These Juicy Deals",
+      "title": "National Cheeseburger Day Is Here\u2014Celebrate With These Juicy Deals",
       "date": "2025-09-16",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/breakfast-in-a-cafe-food-lifestyle-concept-royalty-free-image-1757604872.pjpeg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/national-cheeseburger-day-is-here-celebrate-with-these-juicy-deals-2025-09-16/",
-      "excerpt": "Craving something cheesy? National Cheeseburger Day is September 18, and to celebrate, many of your favorite chains are serving up sizzling hot deals so you can celebrate (in some instances, all week long)—and get that cheese fix taken care of. From buy-one-get-one-free deals …",
+      "excerpt": "Craving something cheesy? National Cheeseburger Day is September 18, and to celebrate, many of your favorite chains are serving up sizzling hot deals so you can celebrate (in some instances, all week long)\u2014and get that cheese fix taken care of. From buy-one-get-one-free deals \u2026",
       "source": "https://www.delish.com/food-news/a66051975/national-cheeseburger-day-deals-2025/"
     },
     {
@@ -380,7 +470,7 @@
     },
     {
       "slug": "i-tried-the-new-popeyes-x-hot-ones-menu-here-s-how-spicy-it-really-is-2025-09-16",
-      "title": "I Tried the New Popeyes x Hot Ones Menu—Here’s How Spicy It Really Is",
+      "title": "I Tried the New Popeyes x Hot Ones Menu\u2014Here\u2019s How Spicy It Really Is",
       "date": "2025-09-16",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/I-Tried-the-New-Popeyes-x-Hot-Ones-Menu_Popeyes-x-Hot-Ones-Full-Line-Up_Dkedit_FT.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/i-tried-the-new-popeyes-x-hot-ones-menu-here-s-how-spicy-it-really-is-2025-09-16/",
@@ -389,20 +479,20 @@
     },
     {
       "slug": "i-tried-costco-s-new-caramel-apple-strudel-bites-they-re-the-warehouse-s-most-polarizing-pastries-2025-09-16",
-      "title": "I Tried Costco’s New Caramel Apple Strudel Bites & They’re The Warehouse’s Most Polarizing Pastries",
+      "title": "I Tried Costco\u2019s New Caramel Apple Strudel Bites & They\u2019re The Warehouse\u2019s Most Polarizing Pastries",
       "date": "2025-09-16",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/img-7896-68c874460fbc9.jpeg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/i-tried-costco-s-new-caramel-apple-strudel-bites-they-re-the-warehouse-s-most-polarizing-pastries-2025-09-16/",
-      "excerpt": "Pumpkin is the de facto darling of fall desserts . From pies to muffins to lattes , you can’t go anywhere without finding it. I don’t want to be a contrarian, but I get excited about autumn for the apples.",
+      "excerpt": "Pumpkin is the de facto darling of fall desserts . From pies to muffins to lattes , you can\u2019t go anywhere without finding it. I don\u2019t want to be a contrarian, but I get excited about autumn for the apples.",
       "source": "https://www.delish.com/food-news/a66109653/costco-apple-strudel-bites-review/"
     },
     {
       "slug": "i-put-the-new-cuisinart-fastfreeze-to-the-test-against-the-ninja-creami-here-s-my-unfiltered-review-2025-09-16",
-      "title": "I Put The New Cuisinart FastFreeze To The Test Against The Ninja CREAMi—Here's My Unfiltered Review",
+      "title": "I Put The New Cuisinart FastFreeze To The Test Against The Ninja CREAMi\u2014Here's My Unfiltered Review",
       "date": "2025-09-16",
       "cover": "https://hips.hearstapps.com/hmg-prod/images/cuisinart-ninja-side-by-side-68c2dcee44691.jpeg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/i-put-the-new-cuisinart-fastfreeze-to-the-test-against-the-ninja-creami-here-s-my-unfiltered-review-2025-09-16/",
-      "excerpt": "Making ice cream at home hasn’t always been easy. Whether you fill a plastic bag with ice or attempt to fit a bulky bowl in the freezer, the process requires a lot more time and effort than grabbing a pint at the grocery store. It almost wasn’t worth the hassle—until Ninja rel…",
+      "excerpt": "Making ice cream at home hasn\u2019t always been easy. Whether you fill a plastic bag with ice or attempt to fit a bulky bowl in the freezer, the process requires a lot more time and effort than grabbing a pint at the grocery store. It almost wasn\u2019t worth the hassle\u2014until Ninja rel\u2026",
       "source": "https://www.delish.com/kitchen-tools/cookware-reviews/a65994866/cuisinart-fastfreeze-review/"
     },
     {
@@ -434,11 +524,11 @@
     },
     {
       "slug": "alex-bala-s-buffalo-chicken-egg-rolls-2025-09-16",
-      "title": "Alex Bala’s Buffalo Chicken Egg Rolls",
+      "title": "Alex Bala\u2019s Buffalo Chicken Egg Rolls",
       "date": "2025-09-16",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/EXPS_TOHCR25_281030_AB_0910_1.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/alex-bala-s-buffalo-chicken-egg-rolls-2025-09-16/",
-      "excerpt": "Buffalo chicken egg rolls are the perfect mashup of comfort food and party snack. They're golden on the outside and creamy and spicy on the inside, and the first thing to go at the party! —Alex Bala, Longmont, Colorado",
+      "excerpt": "Buffalo chicken egg rolls are the perfect mashup of comfort food and party snack. They're golden on the outside and creamy and spicy on the inside, and the first thing to go at the party! \u2014Alex Bala, Longmont, Colorado",
       "source": "https://www.tasteofhome.com/recipes/alex-bala-buffalo-chicken-egg-rolls/"
     },
     {
@@ -452,16 +542,16 @@
     },
     {
       "slug": "elise-jesse-s-maple-dijon-salmon-2025-09-15",
-      "title": "Elise Jesse’s Maple Dijon Salmon",
+      "title": "Elise Jesse\u2019s Maple Dijon Salmon",
       "date": "2025-09-15",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/PS_TOHCR25_280995_EJ_0903_1.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/elise-jesse-s-maple-dijon-salmon-2025-09-15/",
-      "excerpt": "Looking for a quick, healthy, flavorful dinner with minimal cleanup? This maple Dijon salmon (or \"pink steak\" as my kids call it) with green beans is your perfect one-pan solution. Tender salmon fillets are topped with a sweet and tangy maple-Dijon glaze and baked alongside cr…",
+      "excerpt": "Looking for a quick, healthy, flavorful dinner with minimal cleanup? This maple Dijon salmon (or \"pink steak\" as my kids call it) with green beans is your perfect one-pan solution. Tender salmon fillets are topped with a sweet and tangy maple-Dijon glaze and baked alongside cr\u2026",
       "source": "https://www.tasteofhome.com/recipes/elise-jesse-maple-dijon-salmon/"
     },
     {
       "slug": "20-harry-potter-gifts-for-the-kitchen-that-ll-make-you-say-accio-2025-09-15",
-      "title": "20 Harry Potter Gifts for the Kitchen That’ll Make You Say “Accio”!",
+      "title": "20 Harry Potter Gifts for the Kitchen That\u2019ll Make You Say \u201cAccio\u201d!",
       "date": "2025-09-15",
       "cover": "https://www.tasteofhome.com/wp-content/uploads/2019/12/Quidditch-Signature-Round-Dutch-Oven.jpg",
       "canonical": "https://archive.aventuroo.com/food-drink/general/20-harry-potter-gifts-for-the-kitchen-that-ll-make-you-say-accio-2025-09-15/",
@@ -469,11 +559,11 @@
       "source": "https://www.tasteofhome.com/collection/harry-potter-inspired-kitchen-items/"
     }
   ],
-  "count": 52,
+  "count": 62,
   "updated_at": "2025-09-23",
   "pagination": {
-    "total_items": 52,
+    "total_items": 62,
     "per_page": 12,
-    "total_pages": 5
+    "total_pages": 6
   }
 }

--- a/data/hot/manifest.json
+++ b/data/hot/manifest.json
@@ -247,24 +247,13 @@
     },
     {
       "parent": "food-drink",
-      "child": "food-drink",
-      "slug": "food-drink/food-drink",
-      "path": "food-drink/food-drink/index.json",
-      "items": 10,
-      "first_date": "2025-09-18",
-      "last_date": "2025-09-20",
-      "pages": 1,
-      "is_global": false
-    },
-    {
-      "parent": "food-drink",
       "child": "general",
       "slug": "food-drink/general",
       "path": "food-drink/general/index.json",
-      "items": 52,
+      "items": 62,
       "first_date": "2025-09-15",
       "last_date": "2025-09-23",
-      "pages": 5,
+      "pages": 6,
       "is_global": false
     },
     {

--- a/data/hot/summary.json
+++ b/data/hot/summary.json
@@ -169,16 +169,10 @@
           "pages": 4
         },
         {
-          "child": "food-drink",
-          "slug": "food-drink/food-drink",
-          "items": 10,
-          "pages": 1
-        },
-        {
           "child": "general",
           "slug": "food-drink/general",
-          "items": 52,
-          "pages": 5
+          "items": 62,
+          "pages": 6
         }
       ]
     },


### PR DESCRIPTION
## Summary
- add a category alias map that normalizes `index`-style feeds to a `general` standard
- fold `food-drink/food-drink` content into the `food-drink/general` feed and update its counters
- refresh the hot manifest and summary to drop the redundant shard

## Testing
- not run (data-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d3e83f08cc83339f79d8875b8e02f7