### PR TITLE
Recalculate hot manifest and summary for 5-day activity window

### DIFF
--- a/data/hot/manifest.json
+++ b/data/hot/manifest.json
@@ -1,17 +1,17 @@
 {
   "generated_at": "2025-11-13",
   "per_page": 12,
-  "total_items": 2789,
+  "total_items": 4,
   "shards": [
     {
       "parent": "business-finance",
       "child": "companies-startups",
       "slug": "business-finance/companies-startups",
       "path": "business-finance/companies-startups/index.json",
-      "items": 25,
-      "first_date": "2025-09-17",
-      "last_date": "2025-09-23",
-      "pages": 3,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -19,10 +19,10 @@
       "child": "general",
       "slug": "business-finance/general",
       "path": "business-finance/general/index.json",
-      "items": 91,
-      "first_date": "2025-09-10",
-      "last_date": "2025-09-23",
-      "pages": 8,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -30,10 +30,10 @@
       "child": "markets-economy",
       "slug": "business-finance/markets-economy",
       "path": "business-finance/markets-economy/index.json",
-      "items": 43,
-      "first_date": "2025-09-16",
-      "last_date": "2025-09-23",
-      "pages": 4,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -41,10 +41,10 @@
       "child": "personal-finance",
       "slug": "business-finance/personal-finance",
       "path": "business-finance/personal-finance/index.json",
-      "items": 41,
-      "first_date": "2025-08-28",
-      "last_date": "2025-09-23",
-      "pages": 4,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -52,10 +52,10 @@
       "child": "altcoins-web3",
       "slug": "crypto/altcoins-web3",
       "path": "crypto/altcoins-web3/index.json",
-      "items": 46,
-      "first_date": "2025-08-25",
-      "last_date": "2025-09-23",
-      "pages": 4,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -63,10 +63,10 @@
       "child": "bitcoin-majors",
       "slug": "crypto/bitcoin-majors",
       "path": "crypto/bitcoin-majors/index.json",
-      "items": 80,
-      "first_date": "2025-09-17",
-      "last_date": "2025-09-23",
-      "pages": 7,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -74,10 +74,10 @@
       "child": "guides",
       "slug": "crypto/guides",
       "path": "crypto/guides/index.json",
-      "items": 61,
-      "first_date": "2025-09-19",
-      "last_date": "2025-09-23",
-      "pages": 6,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -85,10 +85,10 @@
       "child": "index",
       "slug": "crypto",
       "path": "crypto/index.json",
-      "items": 158,
-      "first_date": "2025-09-11",
-      "last_date": "2025-09-23",
-      "pages": 14,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -96,10 +96,10 @@
       "child": "regulation-security",
       "slug": "crypto/regulation-security",
       "path": "crypto/regulation-security/index.json",
-      "items": 45,
-      "first_date": "2025-09-11",
-      "last_date": "2025-09-23",
-      "pages": 4,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -107,10 +107,10 @@
       "child": "arts",
       "slug": "culture-arts/arts",
       "path": "culture-arts/arts/index.json",
-      "items": 46,
-      "first_date": "2025-09-08",
-      "last_date": "2025-09-23",
-      "pages": 4,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -118,10 +118,10 @@
       "child": "columns-essays",
       "slug": "culture-arts/columns-essays",
       "path": "culture-arts/columns-essays/index.json",
-      "items": 18,
-      "first_date": "2025-08-28",
-      "last_date": "2025-09-20",
-      "pages": 2,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -129,10 +129,10 @@
       "child": "culture",
       "slug": "culture-arts/culture",
       "path": "culture-arts/culture/index.json",
-      "items": 14,
-      "first_date": "2025-09-17",
-      "last_date": "2025-09-23",
-      "pages": 2,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -140,10 +140,10 @@
       "child": "general",
       "slug": "culture-arts/general",
       "path": "culture-arts/general/index.json",
-      "items": 67,
-      "first_date": "2025-08-24",
-      "last_date": "2025-09-22",
-      "pages": 6,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -151,10 +151,10 @@
       "child": "history",
       "slug": "culture-arts/history",
       "path": "culture-arts/history/index.json",
-      "items": 24,
-      "first_date": "2025-09-15",
-      "last_date": "2025-09-23",
-      "pages": 2,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -162,10 +162,10 @@
       "child": "cinematography",
       "slug": "entertainment/cinematography",
       "path": "entertainment/cinematography/index.json",
-      "items": 109,
-      "first_date": "2025-08-28",
-      "last_date": "2025-09-23",
-      "pages": 10,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -173,10 +173,10 @@
       "child": "general",
       "slug": "entertainment/general",
       "path": "entertainment/general/index.json",
-      "items": 68,
-      "first_date": "2025-09-20",
-      "last_date": "2025-09-23",
-      "pages": 6,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -184,10 +184,10 @@
       "child": "history-essays",
       "slug": "entertainment/history-essays",
       "path": "entertainment/history-essays/index.json",
-      "items": 9,
-      "first_date": "2025-09-10",
-      "last_date": "2025-09-23",
-      "pages": 1,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -195,10 +195,10 @@
       "child": "movies",
       "slug": "entertainment/movies",
       "path": "entertainment/movies/index.json",
-      "items": 78,
-      "first_date": "2025-09-17",
-      "last_date": "2025-09-23",
-      "pages": 7,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -206,10 +206,10 @@
       "child": "trailers-latest",
       "slug": "entertainment/trailers-latest",
       "path": "entertainment/trailers-latest/index.json",
-      "items": 56,
-      "first_date": "2025-09-03",
-      "last_date": "2025-09-23",
-      "pages": 5,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -217,10 +217,10 @@
       "child": "tv-streaming",
       "slug": "entertainment/tv-streaming",
       "path": "entertainment/tv-streaming/index.json",
-      "items": 25,
-      "first_date": "2025-09-20",
-      "last_date": "2025-09-23",
-      "pages": 3,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -228,10 +228,10 @@
       "child": "drink",
       "slug": "food-drink/drink",
       "path": "food-drink/drink/index.json",
-      "items": 106,
-      "first_date": "2025-08-25",
-      "last_date": "2025-09-23",
-      "pages": 9,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -239,10 +239,10 @@
       "child": "food",
       "slug": "food-drink/food",
       "path": "food-drink/food/index.json",
-      "items": 40,
-      "first_date": "2025-08-26",
-      "last_date": "2025-09-23",
-      "pages": 4,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -250,10 +250,10 @@
       "child": "general",
       "slug": "food-drink/general",
       "path": "food-drink/general/index.json",
-      "items": 62,
-      "first_date": "2025-09-15",
-      "last_date": "2025-09-23",
-      "pages": 6,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -261,10 +261,10 @@
       "child": "index",
       "slug": "index",
       "path": "index/index.json",
-      "items": 240,
-      "first_date": "2025-09-23",
+      "items": 23,
+      "first_date": "2025-11-09",
       "last_date": "2025-11-13",
-      "pages": 20,
+      "pages": 2,
       "is_global": true
     },
     {
@@ -272,10 +272,10 @@
       "child": "beauty-style",
       "slug": "lifestyle/beauty-style",
       "path": "lifestyle/beauty-style/index.json",
-      "items": 145,
-      "first_date": "2025-09-08",
-      "last_date": "2025-09-23",
-      "pages": 13,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -283,10 +283,10 @@
       "child": "health",
       "slug": "lifestyle/health",
       "path": "lifestyle/health/index.json",
-      "items": 40,
-      "first_date": "2025-09-11",
-      "last_date": "2025-09-23",
-      "pages": 4,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -294,10 +294,10 @@
       "child": "home-design",
       "slug": "lifestyle/home-design",
       "path": "lifestyle/home-design/index.json",
-      "items": 128,
-      "first_date": "2025-09-04",
-      "last_date": "2025-09-23",
-      "pages": 11,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -305,10 +305,10 @@
       "child": "index",
       "slug": "lifestyle",
       "path": "lifestyle/index.json",
-      "items": 12,
-      "first_date": "2025-08-29",
-      "last_date": "2025-09-23",
-      "pages": 1,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -316,10 +316,10 @@
       "child": "inspiration",
       "slug": "lifestyle/inspiration",
       "path": "lifestyle/inspiration/index.json",
-      "items": 36,
-      "first_date": "2025-08-25",
-      "last_date": "2025-09-23",
-      "pages": 3,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -327,10 +327,10 @@
       "child": "outdoor",
       "slug": "lifestyle/outdoor",
       "path": "lifestyle/outdoor/index.json",
-      "items": 67,
-      "first_date": "2025-09-11",
-      "last_date": "2025-09-23",
-      "pages": 6,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -338,10 +338,10 @@
       "child": "economy",
       "slug": "news/economy",
       "path": "news/economy/index.json",
-      "items": 64,
-      "first_date": "2025-09-07",
-      "last_date": "2025-09-23",
-      "pages": 6,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -349,10 +349,10 @@
       "child": "general",
       "slug": "news/general",
       "path": "news/general/index.json",
-      "items": 100,
-      "first_date": "2025-09-19",
-      "last_date": "2025-09-23",
-      "pages": 9,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -360,10 +360,10 @@
       "child": "politics",
       "slug": "news/politics",
       "path": "news/politics/index.json",
-      "items": 65,
-      "first_date": "2025-09-15",
-      "last_date": "2025-09-23",
-      "pages": 6,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -371,10 +371,10 @@
       "child": "top-stories",
       "slug": "news/top-stories",
       "path": "news/top-stories/index.json",
-      "items": 130,
-      "first_date": "2025-09-19",
-      "last_date": "2025-09-23",
-      "pages": 11,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -382,10 +382,10 @@
       "child": "ai-news",
       "slug": "tech-ai/ai-news",
       "path": "tech-ai/ai-news/index.json",
-      "items": 10,
-      "first_date": "2025-09-20",
-      "last_date": "2025-09-23",
-      "pages": 1,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -393,10 +393,10 @@
       "child": "audio-creator",
       "slug": "tech-ai/audio-creator",
       "path": "tech-ai/audio-creator/index.json",
-      "items": 70,
-      "first_date": "2025-09-16",
-      "last_date": "2025-09-23",
-      "pages": 6,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -404,10 +404,10 @@
       "child": "big-tech",
       "slug": "tech-ai/big-tech",
       "path": "tech-ai/big-tech/index.json",
-      "items": 26,
-      "first_date": "2025-09-17",
-      "last_date": "2025-09-23",
-      "pages": 3,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -415,10 +415,10 @@
       "child": "gaming-tech",
       "slug": "tech-ai/gaming-tech",
       "path": "tech-ai/gaming-tech/index.json",
-      "items": 95,
-      "first_date": "2025-09-15",
-      "last_date": "2025-09-23",
-      "pages": 8,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -426,10 +426,10 @@
       "child": "innovation-gadgets",
       "slug": "tech-ai/innovation-gadgets",
       "path": "tech-ai/innovation-gadgets/index.json",
-      "items": 95,
-      "first_date": "2025-09-19",
-      "last_date": "2025-09-23",
-      "pages": 8,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -437,10 +437,10 @@
       "child": "internet-platforms",
       "slug": "tech-ai/internet-platforms",
       "path": "tech-ai/internet-platforms/index.json",
-      "items": 1,
-      "first_date": "2025-09-23",
-      "last_date": "2025-09-23",
-      "pages": 1,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -448,10 +448,10 @@
       "child": "security-privacy",
       "slug": "tech-ai/security-privacy",
       "path": "tech-ai/security-privacy/index.json",
-      "items": 60,
-      "first_date": "2025-08-26",
+      "items": 4,
+      "first_date": "2025-11-09",
       "last_date": "2025-11-13",
-      "pages": 5,
+      "pages": 1,
       "is_global": false
     },
     {
@@ -459,10 +459,10 @@
       "child": "destinations",
       "slug": "travel/destinations",
       "path": "travel/destinations/index.json",
-      "items": 23,
-      "first_date": "2025-08-24",
-      "last_date": "2025-09-22",
-      "pages": 2,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -470,10 +470,10 @@
       "child": "experiences",
       "slug": "travel/experiences",
       "path": "travel/experiences/index.json",
-      "items": 19,
-      "first_date": "2025-09-05",
-      "last_date": "2025-09-22",
-      "pages": 2,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -481,10 +481,10 @@
       "child": "general",
       "slug": "travel/general",
       "path": "travel/general/index.json",
-      "items": 27,
-      "first_date": "2025-09-16",
-      "last_date": "2025-09-23",
-      "pages": 3,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -492,10 +492,10 @@
       "child": "stays-hotels",
       "slug": "travel/stays-hotels",
       "path": "travel/stays-hotels/index.json",
-      "items": 20,
-      "first_date": "2025-08-28",
-      "last_date": "2025-09-22",
-      "pages": 2,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -503,10 +503,10 @@
       "child": "things-to-do",
       "slug": "travel/things-to-do",
       "path": "travel/things-to-do/index.json",
-      "items": 30,
-      "first_date": "2025-09-16",
-      "last_date": "2025-09-22",
-      "pages": 3,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -514,10 +514,10 @@
       "child": "tips-planning",
       "slug": "travel/tips-planning",
       "path": "travel/tips-planning/index.json",
-      "items": 91,
-      "first_date": "2025-09-18",
-      "last_date": "2025-09-23",
-      "pages": 8,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -525,10 +525,10 @@
       "child": "transport",
       "slug": "travel/transport",
       "path": "travel/transport/index.json",
-      "items": 92,
-      "first_date": "2025-08-28",
-      "last_date": "2025-09-23",
-      "pages": 8,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     },
     {
@@ -536,10 +536,10 @@
       "child": "trip-ideas",
       "slug": "travel/trip-ideas",
       "path": "travel/trip-ideas/index.json",
-      "items": 31,
-      "first_date": "2025-08-26",
-      "last_date": "2025-09-23",
-      "pages": 3,
+      "items": 0,
+      "first_date": null,
+      "last_date": null,
+      "pages": 0,
       "is_global": false
     }
   ]

--- a/data/hot/summary.json
+++ b/data/hot/summary.json
@@ -1,356 +1,356 @@
 {
   "generated_at": "2025-11-13",
   "per_page": 12,
-  "total_items": 2789,
+  "total_items": 4,
   "parents": [
     {
       "parent": "business-finance",
-      "items": 200,
-      "pages": 17,
+      "items": 0,
+      "pages": 0,
       "children": [
         {
           "child": "companies-startups",
           "slug": "business-finance/companies-startups",
-          "items": 25,
-          "pages": 3
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "general",
           "slug": "business-finance/general",
-          "items": 91,
-          "pages": 8
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "markets-economy",
           "slug": "business-finance/markets-economy",
-          "items": 43,
-          "pages": 4
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "personal-finance",
           "slug": "business-finance/personal-finance",
-          "items": 41,
-          "pages": 4
+          "items": 0,
+          "pages": 0
         }
       ]
     },
     {
       "parent": "crypto",
-      "items": 390,
-      "pages": 33,
+      "items": 0,
+      "pages": 0,
       "children": [
         {
           "child": "altcoins-web3",
           "slug": "crypto/altcoins-web3",
-          "items": 46,
-          "pages": 4
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "bitcoin-majors",
           "slug": "crypto/bitcoin-majors",
-          "items": 80,
-          "pages": 7
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "guides",
           "slug": "crypto/guides",
-          "items": 61,
-          "pages": 6
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "index",
           "slug": "crypto",
-          "items": 158,
-          "pages": 14
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "regulation-security",
           "slug": "crypto/regulation-security",
-          "items": 45,
-          "pages": 4
+          "items": 0,
+          "pages": 0
         }
       ]
     },
     {
       "parent": "culture-arts",
-      "items": 169,
-      "pages": 15,
+      "items": 0,
+      "pages": 0,
       "children": [
         {
           "child": "arts",
           "slug": "culture-arts/arts",
-          "items": 46,
-          "pages": 4
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "columns-essays",
           "slug": "culture-arts/columns-essays",
-          "items": 18,
-          "pages": 2
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "culture",
           "slug": "culture-arts/culture",
-          "items": 14,
-          "pages": 2
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "general",
           "slug": "culture-arts/general",
-          "items": 67,
-          "pages": 6
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "history",
           "slug": "culture-arts/history",
-          "items": 24,
-          "pages": 2
+          "items": 0,
+          "pages": 0
         }
       ]
     },
     {
       "parent": "entertainment",
-      "items": 345,
-      "pages": 29,
+      "items": 0,
+      "pages": 0,
       "children": [
         {
           "child": "cinematography",
           "slug": "entertainment/cinematography",
-          "items": 109,
-          "pages": 10
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "general",
           "slug": "entertainment/general",
-          "items": 68,
-          "pages": 6
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "history-essays",
           "slug": "entertainment/history-essays",
-          "items": 9,
-          "pages": 1
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "movies",
           "slug": "entertainment/movies",
-          "items": 78,
-          "pages": 7
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "trailers-latest",
           "slug": "entertainment/trailers-latest",
-          "items": 56,
-          "pages": 5
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "tv-streaming",
           "slug": "entertainment/tv-streaming",
-          "items": 25,
-          "pages": 3
+          "items": 0,
+          "pages": 0
         }
       ]
     },
     {
       "parent": "food-drink",
-      "items": 208,
-      "pages": 18,
+      "items": 0,
+      "pages": 0,
       "children": [
         {
           "child": "drink",
           "slug": "food-drink/drink",
-          "items": 106,
-          "pages": 9
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "food",
           "slug": "food-drink/food",
-          "items": 40,
-          "pages": 4
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "general",
           "slug": "food-drink/general",
-          "items": 62,
-          "pages": 6
+          "items": 0,
+          "pages": 0
         }
       ]
     },
     {
       "parent": "lifestyle",
-      "items": 428,
-      "pages": 36,
+      "items": 0,
+      "pages": 0,
       "children": [
         {
           "child": "beauty-style",
           "slug": "lifestyle/beauty-style",
-          "items": 145,
-          "pages": 13
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "health",
           "slug": "lifestyle/health",
-          "items": 40,
-          "pages": 4
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "home-design",
           "slug": "lifestyle/home-design",
-          "items": 128,
-          "pages": 11
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "index",
           "slug": "lifestyle",
-          "items": 12,
-          "pages": 1
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "inspiration",
           "slug": "lifestyle/inspiration",
-          "items": 36,
-          "pages": 3
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "outdoor",
           "slug": "lifestyle/outdoor",
-          "items": 67,
-          "pages": 6
+          "items": 0,
+          "pages": 0
         }
       ]
     },
     {
       "parent": "news",
-      "items": 359,
-      "pages": 30,
+      "items": 0,
+      "pages": 0,
       "children": [
         {
           "child": "economy",
           "slug": "news/economy",
-          "items": 64,
-          "pages": 6
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "general",
           "slug": "news/general",
-          "items": 100,
-          "pages": 9
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "politics",
           "slug": "news/politics",
-          "items": 65,
-          "pages": 6
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "top-stories",
           "slug": "news/top-stories",
-          "items": 130,
-          "pages": 11
+          "items": 0,
+          "pages": 0
         }
       ]
     },
     {
       "parent": "tech-ai",
-      "items": 357,
-      "pages": 30,
+      "items": 4,
+      "pages": 1,
       "children": [
         {
           "child": "ai-news",
           "slug": "tech-ai/ai-news",
-          "items": 10,
-          "pages": 1
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "audio-creator",
           "slug": "tech-ai/audio-creator",
-          "items": 70,
-          "pages": 6
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "big-tech",
           "slug": "tech-ai/big-tech",
-          "items": 26,
-          "pages": 3
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "gaming-tech",
           "slug": "tech-ai/gaming-tech",
-          "items": 95,
-          "pages": 8
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "innovation-gadgets",
           "slug": "tech-ai/innovation-gadgets",
-          "items": 95,
-          "pages": 8
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "internet-platforms",
           "slug": "tech-ai/internet-platforms",
-          "items": 1,
-          "pages": 1
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "security-privacy",
           "slug": "tech-ai/security-privacy",
-          "items": 60,
-          "pages": 5
+          "items": 4,
+          "pages": 1
         }
       ]
     },
     {
       "parent": "travel",
-      "items": 333,
-      "pages": 28,
+      "items": 0,
+      "pages": 0,
       "children": [
         {
           "child": "destinations",
           "slug": "travel/destinations",
-          "items": 23,
-          "pages": 2
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "experiences",
           "slug": "travel/experiences",
-          "items": 19,
-          "pages": 2
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "general",
           "slug": "travel/general",
-          "items": 27,
-          "pages": 3
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "stays-hotels",
           "slug": "travel/stays-hotels",
-          "items": 20,
-          "pages": 2
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "things-to-do",
           "slug": "travel/things-to-do",
-          "items": 30,
-          "pages": 3
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "tips-planning",
           "slug": "travel/tips-planning",
-          "items": 91,
-          "pages": 8
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "transport",
           "slug": "travel/transport",
-          "items": 92,
-          "pages": 8
+          "items": 0,
+          "pages": 0
         },
         {
           "child": "trip-ideas",
           "slug": "travel/trip-ideas",
-          "items": 31,
-          "pages": 3
+          "items": 0,
+          "pages": 0
         }
       ]
     }


### PR DESCRIPTION
## Summary
- regenerate `data/hot/manifest.json` so each shard reflects only items dated within the latest five-day window, zeroing older categories and keeping the tech-ai/security-privacy shard (4 items) plus the global index aggregate (23 items)
- refresh `data/hot/summary.json` to mirror the trimmed manifest, leaving tech-ai/security-privacy as the only active child and setting other category counters to zero

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d41cbf99a883338c76f042ab6271c6