### PR TITLE
Update autopost health reporting

### DIFF
--- a/_health/autopost.json
+++ b/_health/autopost.json
@@ -1,5 +1,6 @@
 {
-  "last_run": "2025-09-23T15:50:38Z",
-  "items_published": 86,
+  "last_fetch": "2025-09-23T15:50:38Z",
+  "feeds_count": 120,
+  "items_ingested": 86,
   "errors": []
 }

--- a/autopost/health.py
+++ b/autopost/health.py
@@ -44,6 +44,20 @@ def _load_existing(path: pathlib.Path) -> dict:
         return {}
 
 
+def _coerce_non_negative_int(value, *, default: int | None = 0) -> int | None:
+    """Return ``value`` coerced to a non-negative ``int`` or ``default``."""
+
+    if value is None:
+        return default
+
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+
+    return max(0, coerced)
+
+
 class HealthReport:
     """Accumulate run errors and persist them to ``_health/<name>.json``."""
 
@@ -51,7 +65,9 @@ class HealthReport:
         self.name = name
         self.health_dir = health_dir or HEALTH_DIR
         self.errors: list[str] = []
+        self._feeds_override: int | None = None
         self._items_override: int | None = None
+        self._last_fetch_override: str | None = None
 
     # Public API ---------------------------------------------------------
     def record_error(self, message: str) -> None:
@@ -63,36 +79,58 @@ class HealthReport:
         for message in messages:
             self.record_error(str(message))
 
-    def set_items_published(self, value: int | None) -> None:
-        if value is None:
-            self._items_override = None
-        else:
-            try:
-                coerced = int(value)
-            except (TypeError, ValueError):
-                coerced = 0
-            self._items_override = max(0, coerced)
+    def set_feeds_count(self, value: int | None) -> None:
+        self._feeds_override = _coerce_non_negative_int(value, default=None)
 
-    def write(self, *, items_published: int | None = None) -> pathlib.Path:
-        if items_published is not None:
-            self.set_items_published(items_published)
+    def set_items_ingested(self, value: int | None) -> None:
+        self._items_override = _coerce_non_negative_int(value, default=None)
+
+    def set_last_fetch(self, value: str | None) -> None:
+        text = str(value or "").strip()
+        self._last_fetch_override = text or None
+
+    @property
+    def has_errors(self) -> bool:
+        return bool(_coerce_errors(self.errors))
+
+    def write(
+        self,
+        *,
+        feeds_count: int | None = None,
+        items_ingested: int | None = None,
+        last_fetch: str | None = None,
+    ) -> pathlib.Path:
+        if feeds_count is not None:
+            self.set_feeds_count(feeds_count)
+        if items_ingested is not None:
+            self.set_items_ingested(items_ingested)
+        if last_fetch is not None:
+            self.set_last_fetch(last_fetch)
 
         path = self.health_dir / f"{self.name}.json"
         existing = _load_existing(path)
 
-        if self._items_override is not None:
-            items_value = self._items_override
-        else:
-            existing_value = existing.get("items_published")
-            try:
-                items_value = int(existing_value)
-            except (TypeError, ValueError):
-                items_value = 0
-            items_value = max(0, items_value)
+        feeds_value = self._feeds_override
+        if feeds_value is None:
+            feeds_value = _coerce_non_negative_int(existing.get("feeds_count"), default=0)
+        if feeds_value is None:
+            feeds_value = 0
+
+        existing_items = existing.get("items_ingested")
+        if existing_items is None:
+            existing_items = existing.get("items_published")
+        items_value = self._items_override
+        if items_value is None:
+            items_value = _coerce_non_negative_int(existing_items, default=0)
+        if items_value is None:
+            items_value = 0
+
+        last_fetch_value = self._last_fetch_override or _utc_now_iso()
 
         payload = {
-            "last_run": _utc_now_iso(),
-            "items_published": items_value,
+            "last_fetch": last_fetch_value,
+            "feeds_count": feeds_value,
+            "items_ingested": items_value,
             "errors": _coerce_errors(self.errors),
         }
 

--- a/scripts/rotate_hot_to_archive.py
+++ b/scripts/rotate_hot_to_archive.py
@@ -908,7 +908,7 @@ def main(argv: Iterable[str] | None = None) -> RotationStats:
         raise
     finally:
         try:
-            health.write(items_published=None)
+            health.write()
         except Exception as health_exc:
             print(
                 f"[rotate] Warning: failed to write autopost health ({health_exc})",


### PR DESCRIPTION
## Summary
- refactor `HealthReport` to track last fetch timestamps, feed counts, and ingested item totals alongside errors
- propagate the new health metrics through the ingest pipeline, raising a non-zero exit when errors are present and updating rotation cleanup to the new API
- refresh the heartbeat documentation, monitoring worker, sample JSON, and add a regression test covering error handling

## Testing
- pytest tests/test_pull_news.py

------
https://chatgpt.com/codex/tasks/task_e_68d42fdea9c48333a30324cffbf8abb2