### PR TITLE
Add contact URL metadata to autopost feeds

### DIFF
--- a/autopost/pull_news.py
+++ b/autopost/pull_news.py
@@ -130,10 +130,23 @@ UA = os.getenv("AP_USER_AGENT", "Mozilla/5.0 (AventurOO Autoposter)")
 FALLBACK_COVER = os.getenv("FALLBACK_COVER", "assets/img/cover-fallback.jpg")
 DEFAULT_AUTHOR = os.getenv("DEFAULT_AUTHOR", "AventurOO Editorial")
 ARCHIVE_BASE_URL = os.getenv("ARCHIVE_BASE_URL", "https://archive.aventuroo.com").strip()
+CONTACT_URL = (
+    os.getenv("CONTACT_URL", "https://www.aventuroo.com/contact").strip()
+    or "https://www.aventuroo.com/contact"
+)
 
 IMPORTANT_FEED_CAP = 10
 
-HOT_ENTRY_FIELDS = ("slug", "title", "date", "cover", "canonical", "excerpt", "source")
+HOT_ENTRY_FIELDS = (
+    "slug",
+    "title",
+    "date",
+    "cover",
+    "canonical",
+    "excerpt",
+    "source",
+    "contact_url",
+)
 HOT_DEFAULT_PARENT_SLUG = "general"
 HOT_DEFAULT_CHILD_SLUG = "index"
 HOT_GLOBAL_PARENT_SLUG = "index"
@@ -972,6 +985,19 @@ def _normalize_post_entry(entry):
     else:
         subcategory = (subcategory or "").strip()
 
+    contact_url_value = normalized.get("contact_url")
+    if isinstance(contact_url_value, str):
+        contact_url_value = contact_url_value.strip()
+    elif contact_url_value is None:
+        contact_url_value = ""
+    else:
+        contact_url_value = str(contact_url_value).strip()
+
+    if contact_url_value:
+        normalized["contact_url"] = contact_url_value
+    else:
+        normalized["contact_url"] = CONTACT_URL
+
     slug_parts = []
     if cat_slug:
         slug_parts.append(cat_slug)
@@ -1011,6 +1037,17 @@ def _normalize_hot_entry(entry):
         if key == "slug":
             continue
         value = entry.get(key)
+        if key == "contact_url":
+            if isinstance(value, str):
+                value = value.strip()
+            elif value is None:
+                value = ""
+            else:
+                value = str(value).strip()
+            if not value:
+                value = CONTACT_URL
+            normalized[key] = value
+            continue
         if value is None:
             continue
         if isinstance(value, str):
@@ -1963,6 +2000,7 @@ def _run_autopost() -> list[dict]:
                 "rights": rights,
                 "body": body_html,
                 "canonical": canonical_path,
+                "contact_url": CONTACT_URL,
             }
 
             existing_slugs.add(slug)

--- a/data/hot/index/index.json
+++ b/data/hot/index/index.json
@@ -4,26 +4,36 @@
   "count": 2,
   "items": [
     {
+      "slug": "ai-startup-unveils-breakthrough-battery-2025-11-13",
       "id": "sample-tech-story",
       "title": "AI Startup Unveils Breakthrough Battery",
       "excerpt": "A lightweight solid-state battery promises faster charging for electric aircraft.",
       "category": "Tech & AI",
       "category_label": "Tech & AI",
       "date": "2025-11-13T07:30:00Z",
+      "published_at": "2025-11-13T07:30:00Z",
+      "created_at": "2025-11-13T08:00:00Z",
+      "canonical": "https://archive.aventuroo.com/tech-ai/ai-startup-unveils-breakthrough-battery-2025-11-13/",
       "url": "https://example.com/tech-ai/sample-story",
       "cover": "https://images.example.com/ai-battery.jpg",
-      "source": "https://example.com/tech-ai/sample-story"
+      "source": "https://example.com/tech-ai/sample-story",
+      "contact_url": "https://www.aventuroo.com/contact"
     },
     {
+      "slug": "sleeper-trains-return-to-continental-europe-2025-11-12",
       "id": "sample-travel-story",
       "title": "Sleeper Trains Return to Continental Europe",
       "excerpt": "Overnight rail makes a comeback with climate-friendly routes across the Alps.",
       "category": "Travel",
       "category_label": "Travel",
       "date": "2025-11-12T18:15:00Z",
+      "published_at": "2025-11-12T18:15:00Z",
+      "created_at": "2025-11-12T19:00:00Z",
+      "canonical": "https://archive.aventuroo.com/travel/sleeper-trains-return-to-continental-europe-2025-11-12/",
       "url": "https://example.com/travel/sleeper-trains",
       "cover": "https://images.example.com/sleeper-train.jpg",
-      "source": "https://example.com/travel/sleeper-trains"
+      "source": "https://example.com/travel/sleeper-trains",
+      "contact_url": "https://www.aventuroo.com/contact"
     }
   ],
   "pagination": {

--- a/scripts/validate_feeds.py
+++ b/scripts/validate_feeds.py
@@ -22,6 +22,7 @@ REQUIRED_ITEM_FIELDS = (
     "source",
     "published_at",
     "created_at",
+    "contact_url",
 )
 
 


### PR DESCRIPTION
## Summary
- add a CONTACT_URL configuration value to the shared autopost pipeline and propagate it into generated entries
- require the contact_url field during feed validation
- refresh the sample hot index payload so it carries the new metadata alongside the existing required fields

## Testing
- python scripts/validate_feeds.py

------
https://chatgpt.com/codex/tasks/task_e_68d4771d8eac83338d1ad4281f57ac10