### PR TITLE
Handle autopost health warnings gracefully

### DIFF
--- a/autopost/pull_news.py
+++ b/autopost/pull_news.py
@@ -52,6 +52,8 @@ def _record_health_error(message: str) -> None:
 _NON_FATAL_HEALTH_PREFIXES: tuple[str, ...] = (
     "fetch_bytes failed:",
     "Failed to parse feed XML:",
+    "limit_words_html failed for ",
+    "cover selection failed for ",
 )
 
 


### PR DESCRIPTION
## Summary
- treat the limit_words_html and cover selection health messages as non-fatal so autopost runs can complete
- add a regression test ensuring these health warnings do not cause pull_news.main() to exit early

## Testing
- pytest tests/test_pull_news.py -q
- pytest tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d47ff520e88333a7f933e9e68d122f