### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,54 @@
+name: Deploy • GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Verify critical data indexes
+        run: node scripts/check-critical-indexes.js
+
+      - name: Build site
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ This generates the static site inside the `_site/` directory. The default
 `.json` output (including the archive/search trees) into `.gz` siblings so that
 the CDN can serve precompressed responses.
 
+## GitHub Pages deployment
+
+The repository ships with a **Deploy • GitHub Pages** workflow that builds the
+site and publishes `_site/` to GitHub Pages. To enable it:
+
+1. Open your repository’s settings in GitHub and navigate to **Pages**.
+2. Choose **GitHub Actions** as the build source.
+3. Optionally create the required secrets (for example, the autopost workflows
+   reference `NEWS_FEEDS_URL` and similar variables) so that the scheduled
+   jobs can run successfully.
+
+Every push to `main`, or a manual `workflow_dispatch`, runs the workflow to
+produce an Eleventy build and deploy it via the official `deploy-pages`
+action. The generated URL is published to the `github-pages` environment once
+the deployment completes.
+
 ## Testim lokal
 
 - **Instalo varësitë JavaScript:** `npm install`


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds Eleventy and deploys the _site output to GitHub Pages
- document the GitHub Pages workflow in the README, including how to enable it and required secrets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d50138177c833383b371809c885f39