### PR TITLE
Configure GitHub Pages action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,57 @@
+name: Deploy • GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Verify critical data indexes
+        run: node scripts/check-critical-indexes.js
+
+      - name: Build site
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ This generates the static site inside the `_site/` directory. The default
 `.json` output (including the archive/search trees) into `.gz` siblings so that
 the CDN can serve precompressed responses.
 
+## GitHub Pages deployment
+
+The repository ships with a **Deploy • GitHub Pages** workflow that builds the
+site and publishes `_site/` to GitHub Pages. To enable it:
+
+1. Open your repository’s settings in GitHub and navigate to **Pages**.
+2. Choose **GitHub Actions** as the build source (if it isn’t already set).
+3. Save the settings so that GitHub provisions the `github-pages` environment
+   the workflow needs for deployment.
+4. Optionally create the required secrets (for example, the autopost workflows
+   reference `NEWS_FEEDS_URL` and similar variables) so that the scheduled
+   jobs can run successfully.
+
+Every push to `main`, or a manual `workflow_dispatch`, runs the workflow to
+produce an Eleventy build and deploy it via the official `deploy-pages`
+action. The generated URL is published to the `github-pages` environment once
+the deployment completes.
+
 ## Testim lokal
 
 - **Instalo varësitë JavaScript:** `npm install`


### PR DESCRIPTION
## Summary
- configure the GitHub Pages workflow using actions/configure-pages before building
- document that GitHub Pages settings must be saved so the github-pages environment is created

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d50138177c833383b371809c885f39