### PR TITLE
Add console debug and menu state marker

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -1,4 +1,5 @@
 (function () {
+  console.debug('menu.js loaded', window.location.href, !!document.querySelector('#menu-list .nav-list'));
   // --------- CONFIG & HELPERS ----------
   var basePath = window.AventurOOBasePath || {
     resolve: function (value) { return value; },

--- a/src/site/_includes/partials/header.njk
+++ b/src/site/_includes/partials/header.njk
@@ -42,7 +42,7 @@
   </div>
 
   <!-- Start nav -->
-  <nav class="menu">
+  <nav id="site-menu" class="menu" data-menustate="boot">
     <div class="container">
       <div class="brand">
         <a href="{{ '/' | url }}">


### PR DESCRIPTION
## Summary
- add a console debug statement to menu.js to log when the script loads and whether the target menu list is present
- tag the navigation element with an id and data-menustate attribute to surface the boot state in devtools

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d55847aafc8333a7acc197b2ee0dde