### PR TITLE
Gate GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ vars.USE_GITHUB_PAGES == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -46,6 +47,7 @@ jobs:
           path: _site
 
   deploy:
+    if: ${{ vars.USE_GITHUB_PAGES == 'true' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- gate the Deploy • GitHub Pages workflow behind the USE_GITHUB_PAGES environment flag so it only runs when enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d579f3840c8333b375b665f75c9079