### PR TITLE
Add hot shard fallback for category loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,11 @@ category feeds once the DOM is ready. A minimal HTML scaffold looks like:
 
 The loader resolves URLs through `window.AventurOOBasePath`, fetches
 `/data/index.json` to populate the menu, requests
-`/data/categories/<slug>/index.json` for the initial post list, and uses the
-`data-load-more` button to walk the archive queue exposed via
+`/data/hot/<slug>/index.json` for the initial post list, and falls back to the
+configured child shard (defaulting to `/data/hot/<slug>/general/index.json`)
+whenever the parent index is missing. Aliases and overrides live in
+`/data/hot/category_aliases.json`. The `data-load-more` button walks the archive
+queue exposed via
 `/data/archive/<slug>/<YYYY>/<MM>.json`.
 
 ## Running the autopost scripts


### PR DESCRIPTION
## Summary
- add client-side fallback so category feeds reuse the configured hot shard when /data/hot/<slug>/index.json is missing
- cache hot alias metadata and reuse it to resolve the general child shard
- document the hot shard paths and fallback behaviour in the README

## Testing
- npm run build
- pytest tests/test_build_posts.py

------
https://chatgpt.com/codex/tasks/task_e_68d5c3f03d148333ae043be05452e6db