### PR TITLE
Protect additional cleanup paths

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -146,6 +146,9 @@ PROTECTED_PATHS=(
   "/assets"
   "/netlify.toml"
   "/_headers"
+  "/autopost"
+  "/.eleventy.js"  # Konfigurim kryesor i ndërtimit
+  "/README.md"      # Dokumentim rrënjësor
 )
 
 PROTECTED_ABS=()


### PR DESCRIPTION
## Summary
- add autopost, Eleventy config, and README paths to the cleanup protection list
- document why the new protected entries must be preserved

## Testing
- scripts/cleanup.sh --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d6c219755083339e1f8fb7d353d807