### PR TITLE
Update cleanup allowlist for new cleanup requirements

### DIFF
--- a/cleanup-allowlist.txt
+++ b/cleanup-allowlist.txt
@@ -1,6 +1,10 @@
 # Shembull allowlist i gjeneruar nga out/audit.json
+# Hyrjet pasqyrojnë kërkesat aktuale të pastrimit (p.sh. out/*.log pritet të trajtohet nga skripti i përditësuar)
 json/
 feeds/
 public/json/
 old_data/
 tmp/
+dist/
+.cache/
+out/*.log


### PR DESCRIPTION
## Summary
- document that the allowlist entries reflect the current cleanup expectations
- allow cleanup.sh to target dist/, .cache/, and out/*.log outputs

## Testing
- scripts/cleanup.sh --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d6e428083c8333bea202478645aefe