### PR TITLE
Add shopping taxonomy and hot shards

### DIFF
--- a/data/hot/manifest.json
+++ b/data/hot/manifest.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2025-11-13",
   "per_page": 12,
-  "total_items": 4133,
+  "total_items": 4195,
   "shards": [
     {
       "parent": "business-finance",
@@ -540,6 +540,83 @@
       "first_date": "2025-08-28",
       "last_date": "2025-09-26",
       "pages": 4,
+      "is_global": false
+    },
+    {
+      "parent": "shopping",
+      "child": "general",
+      "slug": "shopping/general",
+      "path": "shopping/general/index.json",
+      "items": 12,
+      "first_date": "2025-09-24",
+      "last_date": "2025-09-26",
+      "pages": 1,
+      "is_global": false
+    },
+    {
+      "parent": "shopping",
+      "child": "marketplaces",
+      "slug": "shopping/marketplaces",
+      "path": "shopping/marketplaces/index.json",
+      "items": 8,
+      "first_date": "2025-09-24",
+      "last_date": "2025-09-26",
+      "pages": 1,
+      "is_global": false
+    },
+    {
+      "parent": "shopping",
+      "child": "multi-merchant",
+      "slug": "shopping/multi-merchant",
+      "path": "shopping/multi-merchant/index.json",
+      "items": 8,
+      "first_date": "2025-09-24",
+      "last_date": "2025-09-26",
+      "pages": 1,
+      "is_global": false
+    },
+    {
+      "parent": "shopping",
+      "child": "subscriptions",
+      "slug": "shopping/subscriptions",
+      "path": "shopping/subscriptions/index.json",
+      "items": 9,
+      "first_date": "2025-09-24",
+      "last_date": "2025-09-26",
+      "pages": 1,
+      "is_global": false
+    },
+    {
+      "parent": "shopping",
+      "child": "tech-deals",
+      "slug": "shopping/tech-deals",
+      "path": "shopping/tech-deals/index.json",
+      "items": 9,
+      "first_date": "2025-09-25",
+      "last_date": "2025-09-26",
+      "pages": 1,
+      "is_global": false
+    },
+    {
+      "parent": "shopping",
+      "child": "travel-deals",
+      "slug": "shopping/travel-deals",
+      "path": "shopping/travel-deals/index.json",
+      "items": 10,
+      "first_date": "2025-09-24",
+      "last_date": "2025-09-26",
+      "pages": 1,
+      "is_global": false
+    },
+    {
+      "parent": "shopping",
+      "child": "vpn-security",
+      "slug": "shopping/vpn-security",
+      "path": "shopping/vpn-security/index.json",
+      "items": 6,
+      "first_date": "2025-09-24",
+      "last_date": "2025-09-26",
+      "pages": 1,
       "is_global": false
     }
   ]

--- a/data/hot/shopping/general/index.json
+++ b/data/hot/shopping/general/index.json
@@ -1,0 +1,148 @@
+{
+  "items": [
+    {
+      "slug": "middlesbrough-art-week-proves-that-shopping-malls-are-the-galleries-of",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Middlesbrough Art Week proves that shopping malls are the galleries of the future",
+      "cover": "https://www.creativeboom.com/upload/articles/1600/80fd735d088009ade6675f06877818e9a973dcb0_800.jpg",
+      "canonical": "https://archive.aventuroo.com/culture-arts/arts/middlesbrough-art-week-proves-that-shopping-malls-are-the-galleries-of/",
+      "excerpt": "Middlesbrough Art Week proves that shopping malls are the galleries of the future | Creative Boom Subscribe Latest News Inspiration Insight Tips Resources Podcast Community Topics Advertising Animation Art & Culture Creative Industry Digital Film Graphic Design Illustration Ph\u2026",
+      "source": "https://www.creativeboom.com/insight/middlesbrough-art-week-made-me-realise-shopping-malls-are-the-galleries-of-the-future/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "i-m-a-men-s-stylist-and-these-are-the-5-fall-staples-i-m-actually-shop",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "I'm a Men's Stylist, and These Are the 5 Fall Staples I'm Actually Shopping",
+      "cover": "https://cdn.mos.cms.futurecdn.net/YzAu3LFjUQhZpwQWchxCAR-1280-80.jpg",
+      "canonical": "https://archive.aventuroo.com/lifestyle/beauty-style/i-m-a-men-s-stylist-and-these-are-the-5-fall-staples-i-m-actually-shop/",
+      "excerpt": "The 5 Fall Staples a Men's Stylist Is Actually Shopping | Who What Wear '> Who What Wear US Edition US Australia UK Subscribe \u00d7 Search shop with isa Trends Trends sub-nav-trends sub-nav-trends View all Trends Spring Summer Fall Winter Runway Outfits Outfits sub-nav-outfits sub\u2026",
+      "source": "https://www.whowhatwear.com/fashion/shopping/mens-fall-fashion-staples-2025",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "last-call-scapia-s-festive-shopping-offer-this-week-2025-09-25",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Last Call: Scapia\u2019s Festive Shopping Offer This Week",
+      "cover": "https://boardingarea.com/wp-content/uploads/2025/09/abf8a3ffe7d932f326cbc48a7ba06169.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/last-call-scapia-s-festive-shopping-offer-this-week-2025-09-25/",
+      "excerpt": "Last Call: Scapia\u2019s Festive Shopping Offer This Week - Live From A Lounge News Aviation Credit Card Hospitality Loyalty Promotions Press Releases Deals Airlines Hotels Loyalty Programs Products Promotions Reviews Airlines Hotels Lounges Dining Trip Report Index Reader Stories \u2026",
+      "source": "https://boardingarea.com/?blog-post=last-call-scapias-festive-shopping-offer-this-week",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "is-shopping-secondhand-the-perfect-tariff-loophole-2025-09-25",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Is Shopping Secondhand the Perfect Tariff Loophole?",
+      "cover": "https://img.money.com/2025/09/News-Secondhand-Tariffs.jpg?quality=85",
+      "canonical": "https://archive.aventuroo.com/business-finance/personal-finance/is-shopping-secondhand-the-perfect-tariff-loophole-2025-09-25/",
+      "excerpt": "Is Shopping Secondhand the Perfect Tariff Loophole? | Money Close Credit Money's Best, News & Guides Best Credit Repair Companies Best Identity Theft Protection Services Best Credit Monitoring Services Insurance Money's Best, News & Guides Best Long-Term Care Insurance Best Pe\u2026",
+      "source": "https://money.com/rising-apparel-tariffs-boost-secondhand-resale-market/?xid=moneyrss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "more-generous-capital-one-shopping-offers-50-on-50-lululemon-20-ihg-30",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "More generous Capital One Shopping offers: $50 on $50 Lululemon, 20% IHG, 30% Hilton, 18% Choice & more",
+      "cover": "https://boardingarea.com/wp-content/uploads/2025/09/2a7c6dcb0344a6cffc09d3e1bc203f8f.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/more-generous-capital-one-shopping-offers-50-on-50-lululemon-20-ihg-30/",
+      "excerpt": "More generous Capital One Shopping offers: $50 on $50 Lululemon, 20% IHG, 30% Hilton, 18% Choice & more back to top Facebook Instagram RSS Twitter Beginner\u2019s Guide Best Credit Card Offers Best Offers Card Exploration Tool (Beta) All Credit Cards American Express Bank Of Americ\u2026",
+      "source": "https://boardingarea.com/?blog-post=more-generous-capital-one-shopping-offers-50-on-50-lululemon-20-ihg-30-hilton-18-choice-more",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "i-have-high-standards-as-a-shopping-editor-these-are-the-quince-items",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "I Have High Standards as a Shopping Editor\u2014These Are the Quince Items I Think Are Worth It",
+      "cover": "https://hips.hearstapps.com/hmg-prod/images/quincereview-68d1840788d49.png",
+      "canonical": "https://archive.aventuroo.com/lifestyle/beauty-style/i-have-high-standards-as-a-shopping-editor-these-are-the-quince-items/",
+      "excerpt": "Quince Honest Review 2025: Is the Viral Clothing Brand Worth It? A harsh reality: When something sounds too good to be true, it maybe usually is. So when affordable luxury brand Quince began popping up everywhere (IG, TikTok, streaming ads, you name it), I initially dismissed \u2026",
+      "source": "https://www.cosmopolitan.com/style-beauty/fashion/g46651630/quince-review/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "the-samsung-galaxy-s25-fe-is-now-available-and-i-think-it-could-be-the",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "The Samsung Galaxy S25 FE is now available, and I think it could be the top Android phone for most people \u2013 especially with this 24% discount",
+      "cover": "https://cdn.mos.cms.futurecdn.net/R3UYnUyKw92mbcAV7P3ELU-1280-80.jpg",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/the-samsung-galaxy-s25-fe-is-now-available-and-i-think-it-could-be-the/",
+      "excerpt": "The Samsung Galaxy S25 FE is now available, and I think it could be the top Android phone for most people \u2013 especially with this 24% discount | TechRadar Skip to main content Open menu TechRadar the technology experts US Edition Asia Singapore Europe Danmark Suomi Norge Sverig\u2026",
+      "source": "https://www.techradar.com/phones/samsung-phones/the-samsung-galaxy-s25-fe-is-now-available-and-i-think-it-could-be-the-top-android-phone-for-most-people-especially-with-this-24-percent-discount",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "amazon-agrees-to-pay-2-5-billion-to-settle-u-s-lawsuit-over-prime-prog",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Amazon agrees to pay $2.5 billion to settle U.S. lawsuit over Prime program",
+      "cover": "https://media.npr.org/include/images/facebook-default-wide-s1400-c100.jpg",
+      "canonical": "https://archive.aventuroo.com/news/economy/amazon-agrees-to-pay-2-5-billion-to-settle-u-s-lawsuit-over-prime-prog/",
+      "excerpt": "Amazon agrees to pay $2.5 billion to settle U.S. lawsuit over Prime program : NPR Accessibility links Skip to main content Keyboard shortcuts for audio player Open Navigation Menu Newsletters NPR Shop Close Navigation Menu Home News Expand/collapse submenu for News National Wo\u2026",
+      "source": "https://www.npr.org/2025/09/26/nx-s1-5553533/amazon-agrees-to-pay-2-5-billion-to-settle-u-s-lawsuit-over-prime-program",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "amazon-is-using-robots-to-speed-up-deliveries-how-will-it-impact-jobs",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Amazon is using robots to speed up deliveries. How will it impact jobs?",
+      "cover": "https://assets1.cbsnewsstatic.com/hub/i/r/2025/09/25/a6f0e554-5224-4d6c-a1f9-d486b6e12d98/thumbnail/1200x630/7ebe6c2230830cd22c34177023780047/0925-cmo-ogrady.jpg",
+      "canonical": "https://archive.aventuroo.com/news/top-stories/amazon-is-using-robots-to-speed-up-deliveries-how-will-it-impact-jobs/",
+      "excerpt": "Amazon is using robots to speed up deliveries. How will it impact jobs? - CBS News Latest U.S. ICE Interview Kimmel Returns World Politics Entertainment HealthWatch MoneyWatch Crime Space Sports Brand Studio Local News Atlanta Baltimore Bay Area Boston Chicago Colorado Detroit\u2026",
+      "source": "https://www.cbsnews.com/video/amazon-is-using-robots-to-speed-up-deliveries-how-will-it-impact-jobs/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "the-4-walmart-freezer-find-i-make-when-i-don-t-feel-like-cooking-2025",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "The $4 Walmart Freezer Find I Make When I Don\u2019t Feel Like Cooking",
+      "cover": "https://www.tasteofhome.com/wp-content/uploads/2025/09/Walmart-Freezer-Find-I-Make-When-I-Dont-Feel-Like-Cooking_GettyImages-2213487519_FT.jpg",
+      "canonical": "https://archive.aventuroo.com/food-drink/general/the-4-walmart-freezer-find-i-make-when-i-don-t-feel-like-cooking-2025/",
+      "excerpt": "The Best Walmart Freezer Find Is Ready in Minutes and Costs $4 Skip to main content Login Join My Account My Recipe Box My Newsletters My Account Customer Care Log out Search terms Recipes Dinner Easy Recipes Shop Videos Subscribe DOUGLAS RISSING/GETTY IMAGES Home News Grocery\u2026",
+      "source": "https://www.tasteofhome.com/article/walmart-lilys-toaster-grills/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "save-on-travel-for-1-day-only-with-retailmenot-book-on-september-30-20",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Save on Travel for 1 Day Only With RetailMeNot [Book on September 30]",
+      "cover": "https://upgradedpoints.com/wp-content/uploads/2025/09/Miami-Beach-Chair-Setup.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/save-on-travel-for-1-day-only-with-retailmenot-book-on-september-30-20/",
+      "excerpt": "Save on Travel for 1 Day Only With RetailMeNot [September 30] News Credit Cards Credit Cards By Issuer Amex Chase Capital One Citi Mastercard Visa All Credit Card Issuers Best Cards By Type Best Cards Travel Airline Hotel Sign Up Bonus Cash Back Zero Interest Lounge Access Lux\u2026",
+      "source": "https://upgradedpoints.com/news/retailmenot-cash-back-travel-purchases/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "apple-s-25w-magsafe-charger-is-on-sale-for-a-record-low-price-2025-09",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Apple's 25W MagSafe charger is on sale for a record-low price",
+      "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2024-09%2F1a460840-6ee8-11ef-bfff-be3868139751&resize=1400%2C787&client=19f2b5e49a271b2bde77&signature=c26852ac5d5bf272e87e1704dee891548c17a0ae",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/apple-s-25w-magsafe-charger-is-on-sale-for-a-record-low-price-2025-09/",
+      "excerpt": "Apple's 25W MagSafe charger is on sale for a record-low price Sign in Advertisement Advertisement Advertisement Trending : DJI Osmo Nano review iPhone 17 review: Closer to Pro iPhone 17 Pro and Pro Max review iOS 26: Is your iPhone is compatible? October Prime Day: Best early \u2026",
+      "source": "https://www.engadget.com/deals/apples-25w-magsafe-charger-is-on-sale-for-a-record-low-price-143415602.html?src=rss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    }
+  ]
+}

--- a/data/hot/shopping/marketplaces/index.json
+++ b/data/hot/shopping/marketplaces/index.json
@@ -1,0 +1,100 @@
+{
+  "items": [
+    {
+      "slug": "a-broken-business-the-company-behind-the-makeover-of-bankrupt-retailer",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "'A broken business': The company behind the makeover of bankrupt retailer Claire's",
+      "cover": "https://image.cnbcfm.com/api/v1/image/108075016-1734010965492-gettyimages-2189446307-img_2348_lgpg7lgn.jpeg?v=1755693183&amp;w=1920&amp;h=1080",
+      "canonical": "https://archive.aventuroo.com/business-finance/general/a-broken-business-the-company-behind-the-makeover-of-bankrupt-retailer/",
+      "excerpt": "How Ames Watson is planning to reubild tween retailer Claire's Skip Navigation Markets Pre-Markets U.S. Markets Currencies Cryptocurrency Futures & Commodities Bonds Funds & ETFs Business Economy Finance Health & Science Media Real Estate Energy Climate Transportation Industri\u2026",
+      "source": "https://www.cnbc.com/2025/09/26/ames-watson-tween-retailer-claires-rebuild.html",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "retailers-were-always-going-to-drop-xbox-over-game-pass-opinion-2025-0",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Retailers were always going to drop Xbox over Game Pass | Opinion",
+      "cover": "https://assetsio.gnwcdn.com/xbox-series-x-billy-freeman-unsplash.jpg?width=1920&height=1920&fit=bounds&quality=70&format=jpg&auto=webp",
+      "canonical": "https://archive.aventuroo.com/tech-ai/gaming-tech/retailers-were-always-going-to-drop-xbox-over-game-pass-opinion-2025-0/",
+      "excerpt": "Retailers were always going to drop Xbox over Game Pass | Opinion | GamesIndustry.biz Skip to main content Nintendo Switch 2 Layoffs Jobs roundup Financials Critical Consensus Navigation Features News Academy Events Newsletters Video Games Jobs Go Support us Sign in / Create a\u2026",
+      "source": "https://www.gamesindustry.biz/retailers-were-always-going-to-drop-xbox-over-game-pass",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "walmart-teams-up-with-spain-s-la-liga-furthering-the-retailer-s-invest",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Walmart teams up with Spain's La Liga, furthering the retailer's investment in soccer",
+      "cover": "https://image.cnbcfm.com/api/v1/image/108203294-1758722826380-gettyimages-2213971726-AFP_46A233R.jpeg?v=1758722841&amp;w=1920&amp;h=1080",
+      "canonical": "https://archive.aventuroo.com/business-finance/general/walmart-teams-up-with-spain-s-la-liga-furthering-the-retailer-s-invest/",
+      "excerpt": "Walmart joins Spanish La Liga as presenting partner of 'El Cl\u00e1sico' Skip Navigation Markets Pre-Markets U.S. Markets Currencies Cryptocurrency Futures & Commodities Bonds Funds & ETFs Business Economy Finance Health & Science Media Real Estate Energy Climate Transportation Ind\u2026",
+      "source": "https://www.cnbc.com/2025/09/25/walmart-la-liga-presenting-partner-el-clasico.html",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "cross-border-retail-payments-get-overhaul-as-swift-rolls-out-global-sc",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Cross-Border Retail Payments Get Overhaul as Swift Rolls Out Global Scheme",
+      "cover": "https://blockonomi.com/wp-content/uploads/2018/07/swift.jpg",
+      "canonical": "https://archive.aventuroo.com/crypto/guides/cross-border-retail-payments-get-overhaul-as-swift-rolls-out-global-sc/",
+      "excerpt": "Cross-Border Retail Payments Get Overhaul as Swift Rolls Out Global Scheme Facebook X (Twitter) LinkedIn Telegram About Advertise Submit Press Release Contact Facebook X (Twitter) LinkedIn Telegram Prices All Coins Bitcoin Price Ethereum Price Ripple Price EOS Price Litecoin P\u2026",
+      "source": "https://blockonomi.com/cross-border-retail-payments-get-overhaul-as-swift-rolls-out-global-scheme/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "rethink-loyalty-a-challenge-to-retailers-from-harvard-backed-startup-2",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Rethink Loyalty: A Challenge To Retailers From Harvard-Backed Startup",
+      "cover": "https://imageio.forbes.com/specials-images/imageserve/68d581b61f86f7ac2d1e3fb2/0x0.jpg?width=1600",
+      "canonical": "https://archive.aventuroo.com/business-finance/general/rethink-loyalty-a-challenge-to-retailers-from-harvard-backed-startup-2/",
+      "excerpt": "Rethink Loyalty: A Challenge To Retailers From Harvard-Backed Startup Newsletters Games Share a News Tip Featured Featured Breaking News White House Watch Daily Cover Stories The Cloud 100 List | Paid Program America's Top Next-Gen Wealth Advisors | Paid Program Best-In-State \u2026",
+      "source": "https://www.forbes.com/sites/kevinrozario/2025/09/25/rethink-loyalty-a-challenge-to-retailers-from-harvard-backed-startup/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "seasonal-retail-hiring-to-fall-to-lowest-level-since-2009-signaling-tr",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "Seasonal retail hiring to fall to lowest level since 2009, signaling trouble for holidays, report says",
+      "cover": "https://image.cnbcfm.com/api/v1/image/108195351-1757309407276-gettyimages-2233901120-anotherday111707875_x3fai1th.jpeg?v=1758142653&amp;w=1920&amp;h=1080",
+      "canonical": "https://archive.aventuroo.com/business-finance/general/seasonal-retail-hiring-to-fall-to-lowest-level-since-2009-signaling-tr/",
+      "excerpt": "Seasonal hiring 2025 to fall to lowest level since 2009 recession Skip Navigation Markets Pre-Markets U.S. Markets Currencies Cryptocurrency Futures & Commodities Bonds Funds & ETFs Business Economy Finance Health & Science Media Real Estate Energy Climate Transportation Indus\u2026",
+      "source": "https://www.cnbc.com/2025/09/24/seasonal-hiring-2025-to-fall-to-lowest-level-since-2009-recession.html",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "amazon-is-using-robots-to-speed-up-deliveries-how-will-it-impact-jobs",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Amazon is using robots to speed up deliveries. How will it impact jobs?",
+      "cover": "https://assets1.cbsnewsstatic.com/hub/i/r/2025/09/25/a6f0e554-5224-4d6c-a1f9-d486b6e12d98/thumbnail/1200x630/7ebe6c2230830cd22c34177023780047/0925-cmo-ogrady.jpg",
+      "canonical": "https://archive.aventuroo.com/news/top-stories/amazon-is-using-robots-to-speed-up-deliveries-how-will-it-impact-jobs/",
+      "excerpt": "Amazon is using robots to speed up deliveries. How will it impact jobs? - CBS News Latest U.S. ICE Interview Kimmel Returns World Politics Entertainment HealthWatch MoneyWatch Crime Space Sports Brand Studio Local News Atlanta Baltimore Bay Area Boston Chicago Colorado Detroit\u2026",
+      "source": "https://www.cbsnews.com/video/amazon-is-using-robots-to-speed-up-deliveries-how-will-it-impact-jobs/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "amazon-agrees-to-pay-2-5-billion-to-settle-u-s-lawsuit-over-prime-prog",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Amazon agrees to pay $2.5 billion to settle U.S. lawsuit over Prime program",
+      "cover": "https://media.npr.org/include/images/facebook-default-wide-s1400-c100.jpg",
+      "canonical": "https://archive.aventuroo.com/news/economy/amazon-agrees-to-pay-2-5-billion-to-settle-u-s-lawsuit-over-prime-prog/",
+      "excerpt": "Amazon agrees to pay $2.5 billion to settle U.S. lawsuit over Prime program : NPR Accessibility links Skip to main content Keyboard shortcuts for audio player Open Navigation Menu Newsletters NPR Shop Close Navigation Menu Home News Expand/collapse submenu for News National Wo\u2026",
+      "source": "https://www.npr.org/2025/09/26/nx-s1-5553533/amazon-agrees-to-pay-2-5-billion-to-settle-u-s-lawsuit-over-prime-program",
+      "contact_url": "https://www.aventuroo.com/contact"
+    }
+  ]
+}

--- a/data/hot/shopping/multi-merchant/index.json
+++ b/data/hot/shopping/multi-merchant/index.json
@@ -1,0 +1,100 @@
+{
+  "items": [
+    {
+      "slug": "more-generous-capital-one-shopping-offers-50-on-50-lululemon-20-ihg-30",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "More generous Capital One Shopping offers: $50 on $50 Lululemon, 20% IHG, 30% Hilton, 18% Choice & more",
+      "cover": "https://boardingarea.com/wp-content/uploads/2025/09/2a7c6dcb0344a6cffc09d3e1bc203f8f.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/more-generous-capital-one-shopping-offers-50-on-50-lululemon-20-ihg-30/",
+      "excerpt": "More generous Capital One Shopping offers: $50 on $50 Lululemon, 20% IHG, 30% Hilton, 18% Choice & more back to top Facebook Instagram RSS Twitter Beginner\u2019s Guide Best Credit Card Offers Best Offers Card Exploration Tool (Beta) All Credit Cards American Express Bank Of Americ\u2026",
+      "source": "https://boardingarea.com/?blog-post=more-generous-capital-one-shopping-offers-50-on-50-lululemon-20-ihg-30-hilton-18-choice-more",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "save-on-travel-for-1-day-only-with-retailmenot-book-on-september-30-20",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Save on Travel for 1 Day Only With RetailMeNot [Book on September 30]",
+      "cover": "https://upgradedpoints.com/wp-content/uploads/2025/09/Miami-Beach-Chair-Setup.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/save-on-travel-for-1-day-only-with-retailmenot-book-on-september-30-20/",
+      "excerpt": "Save on Travel for 1 Day Only With RetailMeNot [September 30] News Credit Cards Credit Cards By Issuer Amex Chase Capital One Citi Mastercard Visa All Credit Card Issuers Best Cards By Type Best Cards Travel Airline Hotel Sign Up Bonus Cash Back Zero Interest Lounge Access Lux\u2026",
+      "source": "https://upgradedpoints.com/news/retailmenot-cash-back-travel-purchases/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "30-best-prime-day-furniture-deals-2025-shop-up-to-30-off-2025-09-25",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "30 Best Prime Day Furniture Deals 2025: Shop Up to 30% Off",
+      "cover": "https://media.architecturaldigest.com/photos/66f5d5623902c8d9956f955b/master/pass/bathroomdetaqil21439.jpg",
+      "canonical": "https://archive.aventuroo.com/lifestyle/home-design/30-best-prime-day-furniture-deals-2025-shop-up-to-30-off-2025-09-25/",
+      "excerpt": "30 Best Prime Day Furniture Deals 2025: Shop Up to 30% Off | Architectural Digest Skip to main content AD PRO DIRECTORY APPLY NOW DIRECTORY ARCHITECTURE + DESIGN SHOPPING CELEBRITY AD IT YOURSELF AD PRO Menu Menu Search Menu Menu Decor Under $300 The Newest Arrivals Amy Astley\u2026",
+      "source": "https://www.architecturaldigest.com/story/prime-day-furniture-deals-09-25-2025",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "22-best-early-k-beauty-amazon-prime-day-deals-2025-for-a-glass-skin-gl",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "22 Best Early K-Beauty Amazon Prime Day Deals 2025 for a Glass-Skin Glow",
+      "cover": "https://media.allure.com/photos/68d55946dbab1700c3f70506/master/pass/AdobeStock_871114879.jpeg",
+      "canonical": "https://archive.aventuroo.com/lifestyle/beauty-style/22-best-early-k-beauty-amazon-prime-day-deals-2025-for-a-glass-skin-gl/",
+      "excerpt": "22 Best Early K-Beauty Amazon Prime Day Deals 2025 for a Glass-Skin Glow | Allure Skip to main content Newsletter Sign In Search Search Newsletter Best of Beauty News Skin Makeup Hair Nails Wellness Shopping Allure Beauty Box Newsletter Video GLASS SKIN DISCOUNTS 22 Best Early\u2026",
+      "source": "https://www.allure.com/story/early-amazon-prime-day-korean-beauty-deals-october-2025-1",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "30-early-prime-day-beauty-deals-2025-to-add-to-cart-now-2025-09-24",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "30+ Early Prime Day Beauty Deals 2025 to Add to Cart Now",
+      "cover": "https://media.allure.com/photos/68d309f597819f4ed2c38669/master/pass/9.23_ALL_Early_October_Prime_Day_Beauty_Deals.jpg",
+      "canonical": "https://archive.aventuroo.com/lifestyle/beauty-style/30-early-prime-day-beauty-deals-2025-to-add-to-cart-now-2025-09-24/",
+      "excerpt": "30+ Early Prime Day Beauty Deals 2025 to Add to Cart Now | Allure Skip to main content Newsletter Sign In Search Search Newsletter Best of Beauty News Skin Makeup Hair Nails Wellness Shopping Allure Beauty Box Newsletter Video EARLY BIRD GETS THE WORM 30+ Early Prime Day Beaut\u2026",
+      "source": "https://www.allure.com/story/early-amazon-prime-day-beauty-deals-october-2025-1",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "prime-day-deals-include-two-blink-mini-2-cameras-for-35-2025-09-24",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "Prime Day deals include two Blink Mini 2 cameras for $35",
+      "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2025-09%2F8cc46f00-9981-11f0-bdff-8b255985bb5b&resize=1400%2C786&client=19f2b5e49a271b2bde77&signature=af6cab676ac423e7c8ac8ae072e837d81b935025",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/prime-day-deals-include-two-blink-mini-2-cameras-for-35-2025-09-24/",
+      "excerpt": "Prime Day deals include two Blink Mini 2 cameras for $35 Sign in Advertisement Advertisement Advertisement Trending : DJI Osmo Nano review iPhone 17 review: Closer to Pro iPhone 17 Pro and Pro Max review iOS 26: Is your iPhone is compatible? October Prime Day: Best early deals\u2026",
+      "source": "https://www.engadget.com/deals/prime-day-deals-include-two-blink-mini-2-cameras-for-35-201049269.html?src=rss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "amazon-has-steep-sales-on-holiday-decor-ahead-of-october-prime-day-get",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "Amazon Has Steep Sales on Holiday Decor Ahead of October Prime Day\u2014Get Up to 70% Off",
+      "cover": "https://hips.hearstapps.com/hmg-prod/images/christmas-tree-resized-68d40d293dcd0.jpg",
+      "canonical": "https://archive.aventuroo.com/lifestyle/home-design/amazon-has-steep-sales-on-holiday-decor-ahead-of-october-prime-day-get/",
+      "excerpt": "Christmas Decor Is Already Up to 70% Off Before October Prime Day We use technologies that provide information about your interactions with this site to others for functionality, analytics, targeted advertising, and other uses. Learn more in our Privacy Notice. Search Subscrib\u2026",
+      "source": "https://www.housebeautiful.com/shopping/best-stores/a68000292/prime-day-holiday-christmas-decorations-sales-october-2025/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "i-already-have-two-vacuums-but-i-m-buying-another-because-this-early-o",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "I Already Have Two Vacuums\u2014But I'm Buying Another Because This Early October Prime Day Deal Is That GOOD",
+      "cover": "https://hips.hearstapps.com/hmg-prod/images/pd-vacuums-685af3f5a2bb0.jpeg",
+      "canonical": "https://archive.aventuroo.com/lifestyle/home-design/i-already-have-two-vacuums-but-i-m-buying-another-because-this-early-o/",
+      "excerpt": "The Best Amazon October Prime Day Vacuum Deals 2025 We use technologies that provide information about your interactions with this site to others for functionality, analytics, targeted advertising, and other uses. Learn more in our Privacy Notice. Search Subscribe Leanne Ford \u2026",
+      "source": "https://www.housebeautiful.com/shopping/best-stores/a68036695/amazon-prime-day-october-vacuum-deals-2025/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    }
+  ]
+}

--- a/data/hot/shopping/subscriptions/index.json
+++ b/data/hot/shopping/subscriptions/index.json
@@ -1,0 +1,112 @@
+{
+  "items": [
+    {
+      "slug": "amazon-will-cough-up-2-5-billion-for-tricking-people-into-amazon-prime",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Amazon Will Cough Up $2.5 Billion for 'Tricking' People Into Amazon Prime Subscriptions",
+      "cover": "https://www.cnet.com/a/img/resize/7f1b4e47aadfcf112dbae0f2463e69cdf264dbc3/hub/2025/09/26/f91da03f-4181-4371-adb5-d2b49fea9eaa/amazon-building-texas-gettyimages-2219738045.jpg?auto=webp&fit=crop&height=614&width=1600",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/amazon-will-cough-up-2-5-billion-for-tricking-people-into-amazon-prime/",
+      "excerpt": "Amazon Will Cough Up $2.5 Billion for 'Tricking' People Into Amazon Prime Subscriptions - CNET X Your Guide To a Better Future News AI Tech VPN Phones Laptops Audio TV Services & Software Computers All Tech Home Home Security Smart Home Kitchen & Household Yard & Outdoors Home\u2026",
+      "source": "https://www.cnet.com/news/amazon-will-cough-up-2-5-billion-for-tricking-people-into-amazon-prime-subscriptions/#ftag=CADf328eec",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "amazon-to-pay-2-5-billion-in-prime-membership-settlement-2025-09-25",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Amazon to Pay $2.5 Billion in Prime Membership Settlement",
+      "cover": "https://static01.nyt.com/images/2025/09/25/multimedia/25biz-amazon-ftc-gqbf/25biz-amazon-ftc-gqbf-mediumSquareAt3X.jpg",
+      "canonical": "https://archive.aventuroo.com/news/top-stories/amazon-to-pay-2-5-billion-in-prime-membership-settlement-2025-09-25/",
+      "excerpt": "The settlement is one of the largest in the history of the Federal Trade Commission, which sued Amazon two years ago.",
+      "source": "https://www.nytimes.com/2025/09/25/technology/amazon-ftc-settlement.html",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "amazon-pays-2-5-billion-to-settle-prime-memberships-lawsuit-2025-09-25",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Amazon pays $2.5 billion to settle Prime memberships lawsuit",
+      "cover": "https://www.bleepstatic.com/content/hl-images/2024/10/15/amazon-logo.jpg",
+      "canonical": "https://archive.aventuroo.com/tech-ai/security-privacy/amazon-pays-2-5-billion-to-settle-prime-memberships-lawsuit-2025-09-25/",
+      "excerpt": "Amazon pays $2.5 billion to settle Prime memberships lawsuit News Featured Latest GitHub notifications abused to impersonate Y Combinator for crypto theft Google: Brickstorm malware used to steal U.S. orgs' data for over a year New EDR-Freeze tool uses Windows WER to suspend s\u2026",
+      "source": "https://www.bleepingcomputer.com/news/technology/amazon-pays-25-billion-to-settle-prime-memberships-lawsuit/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "this-secure-ssd-subscription-service-may-well-be-the-perfect-protectio",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "This secure SSD subscription service may well be the perfect protection against physical tampering and a ransomware attack - but it's neither cheap nor fast",
+      "cover": "https://cdn.mos.cms.futurecdn.net/NMMKgQA6drBJwNXYzSqhYF-1280-80.jpg",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/this-secure-ssd-subscription-service-may-well-be-the-perfect-protectio/",
+      "excerpt": "New AI powered SSD subscription promises ransomware and tampering protection at the hardware level | TechRadar Skip to main content svg]:h-4 [&>svg]:w-fit\" aria-label=\"Home\" data-before-rewrite-localise=\"/\"> Tech Radar svg]:h-4 [&>svg]:w-fit\" aria-label=\"Tech Radar Pro\" data-b\u2026",
+      "source": "https://www.techradar.com/pro/this-secure-ssd-subscription-service-may-well-be-the-perfect-protection-against-physical-tampering-and-a-ransomware-attack-but-its-neither-cheap-nor-fast",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "i-m-a-smart-home-tech-editor-and-these-are-my-3-favorite-cheap-video-d",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "I'm a smart home tech editor, and these are my 3 favorite cheap video doorbells \u2013 with no sneaky subscription fees",
+      "cover": "https://cdn.mos.cms.futurecdn.net/FuaQvc7WbLaNLdsqxh4n8c-1280-80.jpg",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/i-m-a-smart-home-tech-editor-and-these-are-my-3-favorite-cheap-video-d/",
+      "excerpt": "I'm a smart home tech editor, and these are my 3 favorite cheap video doorbells \u2013 with no sneaky subscription fees | TechRadar Skip to main content Open menu TechRadar the technology experts US Edition Asia Singapore Europe Danmark Suomi Norge Sverige UK Italia Nederland Belgi\u2026",
+      "source": "https://www.techradar.com/home/home-security/im-a-smart-home-tech-editor-and-these-are-my-3-favorite-cheap-video-doorbells-with-no-sneaky-subscription-fees",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "avelo-introduces-avelo-plus-membership-program-priority-boarding-exclu",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Avelo Introduces Avelo Plus Membership Program [Priority Boarding, Exclusive Fares, and More]",
+      "cover": "https://upgradedpoints.com/wp-content/uploads/2025/03/Avelo-737-700-HVN-Takeoff-Stop-Sign.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/avelo-introduces-avelo-plus-membership-program-priority-boarding-exclu/",
+      "excerpt": "Avelo Introduces Avelo Plus [$49 for the First Year!] News Credit Cards Credit Cards By Issuer Amex Chase Capital One Citi Mastercard Visa All Credit Card Issuers Best Cards By Type Best Cards Travel Airline Hotel Sign Up Bonus Cash Back Zero Interest Lounge Access Luxury Mili\u2026",
+      "source": "https://upgradedpoints.com/news/avelo-introduces-avelo-plus-program/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "costco-tops-earnings-revenue-estimates-as-warehouse-club-gains-more-me",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Costco tops earnings, revenue estimates as warehouse club gains more members",
+      "cover": "https://image.cnbcfm.com/api/v1/image/108199380-1758036121407-gettyimages-2216999918-COSTCO_EARNS.jpeg?v=1758634514&amp;w=1920&amp;h=1080",
+      "canonical": "https://archive.aventuroo.com/business-finance/general/costco-tops-earnings-revenue-estimates-as-warehouse-club-gains-more-me/",
+      "excerpt": "Costco (COST) Q4 2025 earnings Skip Navigation Markets Pre-Markets U.S. Markets Currencies Cryptocurrency Futures & Commodities Bonds Funds & ETFs Business Economy Finance Health & Science Media Real Estate Energy Climate Transportation Industrials Retail Wealth Sports Life Sm\u2026",
+      "source": "https://www.cnbc.com/2025/09/25/costco-cost-q4-2025-earnings.html",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "amex-membership-rewards-transfer-partners-redeem-your-points-with-airl",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "Amex Membership Rewards transfer partners: Redeem your points with airlines and hotels",
+      "cover": "https://runway-media-production.global.ssl.fastly.net/us/originals/2024/06/20240617_Qatar-Airways-QSuite_Qatar-Qsuite-777-cabin-2_ERosen_7.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/amex-membership-rewards-transfer-partners-redeem-your-points-with-airl/",
+      "excerpt": "Amex Membership Rewards transfer partners: Redeem your points with airlines and hotels - The Points Guy Skip to content Menu Go to Home Page Subscribe Advertiser disclosure Search The Points Guy Advertiser disclosure ADVERTISEMENT Guides Amex Membership Rewards transfer partne\u2026",
+      "source": "https://thepointsguy.com/credit-cards/membership-rewards-partner-guide/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "starbreeze-entertainment-launches-payday-2-subscription-service-on-ste",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "Starbreeze Entertainment launches Payday 2 subscription service on Steam",
+      "cover": "https://assetsio.gnwcdn.com/ss_2a509c2ca0c9bae3f9cf32a3a3128ad98ed361f0.1920x1080.jpg?width=1920&height=1920&fit=bounds&quality=70&format=jpg&auto=webp",
+      "canonical": "https://archive.aventuroo.com/tech-ai/gaming-tech/starbreeze-entertainment-launches-payday-2-subscription-service-on-ste/",
+      "excerpt": "Starbreeze Entertainment launches Payday 2 subscription service on Steam | GamesIndustry.biz Skip to main content Nintendo Switch 2 Layoffs Jobs roundup Financials Critical Consensus Navigation Features News Academy Events Newsletters Video Games Jobs Go Support us Sign in / C\u2026",
+      "source": "https://www.gamesindustry.biz/starbreeze-entertainment-launches-payday-2-subscription-service-on-steam",
+      "contact_url": "https://www.aventuroo.com/contact"
+    }
+  ]
+}

--- a/data/hot/shopping/tech-deals/index.json
+++ b/data/hot/shopping/tech-deals/index.json
@@ -1,0 +1,112 @@
+{
+  "items": [
+    {
+      "slug": "today-s-best-ipad-deals-include-a-record-low-price-on-the-latest-ipad",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Today's best iPad deals include a record-low price on the latest iPad Air M3",
+      "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2025-09%2Fee5534d0-9af2-11f0-be5f-8585e5963e03&resize=1400%2C933&client=19f2b5e49a271b2bde77&signature=dd8eab6b48463bb22121af63d3cc064825333d30",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/today-s-best-ipad-deals-include-a-record-low-price-on-the-latest-ipad/",
+      "excerpt": "Today's best iPad deals include a record-low price on the latest iPad Air M3 Sign in Advertisement Advertisement Advertisement Trending : DJI Osmo Nano review iPhone 17 review: Closer to Pro iPhone 17 Pro and Pro Max review iOS 26: Is your iPhone is compatible? October Prime D\u2026",
+      "source": "https://www.engadget.com/deals/todays-best-ipad-deals-include-a-record-low-price-on-the-latest-ipad-air-m3-150020567.html?src=rss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "best-drone-deals-on-amazon-this-week-2025-09-26",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Best Drone Deals on Amazon This Week",
+      "cover": "https://flyingmag1.b-cdn.net/wp-content/uploads/sites/2/2025/09/81BobjYtNzL._AC_SL1500.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/transport/best-drone-deals-on-amazon-this-week-2025-09-26/",
+      "excerpt": "Best Drone Deals on Amazon This Week Brands Search Close Search for: Search Top Stories Aircraft Avionics & Gear Training Modern Flying Flight Schools Podcast Shop Digital Subscribers Library The Flying Shop Newsletters Subscribe Click here to open Menu Home / Guides / Best Dr\u2026",
+      "source": "https://www.flyingmag.com/drone-deals-under-500-this-week/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "best-flight-sim-gear-deals-on-amazon-this-week-2025-09-25",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Best Flight Sim Gear Deals on Amazon This Week",
+      "cover": "https://flyingmag1.b-cdn.net/wp-content/uploads/sites/2/2025/09/FLY11_24_FEAT3_b-x-scaled-1.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/transport/best-flight-sim-gear-deals-on-amazon-this-week-2025-09-25/",
+      "excerpt": "Best Flight Sim Gear Deals on Amazon This Week Brands Search Close Search for: Search Top Stories Aircraft Avionics & Gear Training Modern Flying Flight Schools Podcast Shop Digital Subscribers Library The Flying Shop Newsletters Subscribe Click here to open Menu Home / Guides\u2026",
+      "source": "https://www.flyingmag.com/best-flight-simulator-deals-amazon/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "as-your-tech-pro-bestie-these-early-october-prime-day-deals-are-no-jok",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "As Your Tech Pro Bestie, These Early October Prime Day Deals Are No Joke",
+      "cover": "https://hips.hearstapps.com/hmg-prod/images/gettyimages-2234650682-1-1-68d3026174720.jpg",
+      "canonical": "https://archive.aventuroo.com/lifestyle/beauty-style/as-your-tech-pro-bestie-these-early-october-prime-day-deals-are-no-jok/",
+      "excerpt": "I'm a Tech Expert\u2014These Early October Prime Day Deals Are No Joke Didn't we just have a Prime Day ? Yep, in July. But Amazon's like that friend who throws back-to-back parties. And who are we to complain? October's version of Prime Day (Prime Big Deal Days, if you feel like ca\u2026",
+      "source": "https://www.cosmopolitan.com/lifestyle/g68057623/best-prime-day-tech-deals-october-2025/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "get-two-blink-mini-2-cameras-for-only-35-with-this-prime-day-deal-2025",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Get two Blink Mini 2 cameras for only $35 with this Prime Day deal",
+      "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2025-09%2F8cc46f00-9981-11f0-bdff-8b255985bb5b&resize=1400%2C786&client=19f2b5e49a271b2bde77&signature=af6cab676ac423e7c8ac8ae072e837d81b935025",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/get-two-blink-mini-2-cameras-for-only-35-with-this-prime-day-deal-2025/",
+      "excerpt": "Get two Blink Mini 2 cameras for only $35 with this Prime Day deal Sign in Advertisement Advertisement Advertisement Trending : DJI Osmo Nano review iPhone 17 review: Closer to Pro iPhone 17 Pro and Pro Max review iOS 26: Is your iPhone is compatible? October Prime Day: Best e\u2026",
+      "source": "https://www.engadget.com/deals/get-two-blink-mini-2-cameras-for-only-35-with-this-prime-day-deal-201049776.html?src=rss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "this-battery-powered-ring-doorbell-is-47-percent-off-ahead-of-prime-da",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "This battery-powered Ring doorbell is 47 percent off ahead of Prime Day",
+      "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2023-03%2F8b30e8b0-b9de-11ed-81af-1496d21347e4&resize=1400%2C787&client=19f2b5e49a271b2bde77&signature=609adc4f3fc08f4cf3cbe34f09e456f00ca345e7",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/this-battery-powered-ring-doorbell-is-47-percent-off-ahead-of-prime-da/",
+      "excerpt": "This battery-powered Ring doorbell is 47 percent off ahead of Prime Day Sign in Advertisement Advertisement Advertisement Trending : DJI Osmo Nano review iPhone 17 review: Closer to Pro iPhone 17 Pro and Pro Max review iOS 26: Is your iPhone is compatible? October Prime Day: B\u2026",
+      "source": "https://www.engadget.com/deals/this-battery-powered-ring-doorbell-is-47-percent-off-ahead-of-prime-day-154508654.html?src=rss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "prime-day-deals-include-this-shark-ai-ultra-robot-vacuum-for-58-percen",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Prime Day deals include this Shark AI Ultra robot vacuum for 58 percent off",
+      "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2025-09%2Fdd960e50-9a2d-11f0-bfdb-ccf1a9eea48f&resize=1400%2C787&client=19f2b5e49a271b2bde77&signature=374bd5f086d850dc18cfde692bb5f8355e28154f",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/prime-day-deals-include-this-shark-ai-ultra-robot-vacuum-for-58-percen/",
+      "excerpt": "Prime Day deals include this Shark AI Ultra robot vacuum for 58 percent off Sign in Advertisement Advertisement Advertisement Trending : DJI Osmo Nano review iPhone 17 review: Closer to Pro iPhone 17 Pro and Pro Max review iOS 26: Is your iPhone is compatible? October Prime Da\u2026",
+      "source": "https://www.engadget.com/deals/prime-day-deals-include-this-shark-ai-ultra-robot-vacuum-for-58-percent-off-171836638.html?src=rss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "apple-s-25w-magsafe-charger-is-on-sale-for-a-record-low-price-2025-09",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Apple's 25W MagSafe charger is on sale for a record-low price",
+      "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2024-09%2F1a460840-6ee8-11ef-bfff-be3868139751&resize=1400%2C787&client=19f2b5e49a271b2bde77&signature=c26852ac5d5bf272e87e1704dee891548c17a0ae",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/apple-s-25w-magsafe-charger-is-on-sale-for-a-record-low-price-2025-09/",
+      "excerpt": "Apple's 25W MagSafe charger is on sale for a record-low price Sign in Advertisement Advertisement Advertisement Trending : DJI Osmo Nano review iPhone 17 review: Closer to Pro iPhone 17 Pro and Pro Max review iOS 26: Is your iPhone is compatible? October Prime Day: Best early \u2026",
+      "source": "https://www.engadget.com/deals/apples-25w-magsafe-charger-is-on-sale-for-a-record-low-price-143415602.html?src=rss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "the-samsung-galaxy-s25-fe-is-now-available-and-i-think-it-could-be-the",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "The Samsung Galaxy S25 FE is now available, and I think it could be the top Android phone for most people \u2013 especially with this 24% discount",
+      "cover": "https://cdn.mos.cms.futurecdn.net/R3UYnUyKw92mbcAV7P3ELU-1280-80.jpg",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/the-samsung-galaxy-s25-fe-is-now-available-and-i-think-it-could-be-the/",
+      "excerpt": "The Samsung Galaxy S25 FE is now available, and I think it could be the top Android phone for most people \u2013 especially with this 24% discount | TechRadar Skip to main content Open menu TechRadar the technology experts US Edition Asia Singapore Europe Danmark Suomi Norge Sverig\u2026",
+      "source": "https://www.techradar.com/phones/samsung-phones/the-samsung-galaxy-s25-fe-is-now-available-and-i-think-it-could-be-the-top-android-phone-for-most-people-especially-with-this-24-percent-discount",
+      "contact_url": "https://www.aventuroo.com/contact"
+    }
+  ]
+}

--- a/data/hot/shopping/travel-deals/index.json
+++ b/data/hot/shopping/travel-deals/index.json
@@ -1,0 +1,124 @@
+{
+  "items": [
+    {
+      "slug": "still-available-earn-90-000-chase-ultimate-rewards-points-with-these-o",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Still available: Earn 90,000 Chase Ultimate Rewards points with these offers!",
+      "cover": "https://boardingarea.com/wp-content/uploads/2025/09/c73dafd3618d6fb7097bc2a7305e8195.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/still-available-earn-90-000-chase-ultimate-rewards-points-with-these-o/",
+      "excerpt": "Still available: Earn 90,000 Chase Ultimate Rewards points with these offers! - TravelUpdate Airlines Hotels News Reviews and Reports Airlines Hotels News Reviews and Reports dark Hand-Picked Top-Read Stories Still available: Earn 90,000 Chase Ultimate Rewards points with thes\u2026",
+      "source": "https://boardingarea.com/?blog-post=still-available-earn-90000-chase-ultimate-rewards-points-with-these-offers",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "missed-100k-points-earlier-this-year-this-sapphire-preferred-bonus-off",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Missed 100K Points Earlier This Year? This Sapphire Preferred Bonus Offer Is Worth $1,500+",
+      "cover": "https://upgradedpoints.com/wp-content/uploads/2025/06/Chase-Sapphire-Preferred-Upgraded-Points-LLC.png",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/missed-100k-points-earlier-this-year-this-sapphire-preferred-bonus-off/",
+      "excerpt": "Missed 100K? This Sapphire Preferred Bonus Is Worth $1,500+ News Credit Cards Credit Cards By Issuer Amex Chase Capital One Citi Mastercard Visa All Credit Card Issuers Best Cards By Type Best Cards Travel Airline Hotel Sign Up Bonus Cash Back Zero Interest Lounge Access Luxur\u2026",
+      "source": "https://upgradedpoints.com/news/chase-sapphire-preferred-75k-sign-up-bonus-value/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "amex-offers-alaska-airlines-spend-300-get-60-back-2025-09-26",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Amex Offers: Alaska Airlines Spend $300 get $60 back",
+      "cover": "https://boardingarea.com/wp-content/uploads/2025/09/c2396f1782d5341c50f946acecff2b2a.jpeg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/amex-offers-alaska-airlines-spend-300-get-60-back-2025-09-26/",
+      "excerpt": "Amex Offers: Alaska Airlines Spend $300 get $60 back - Monkey Miles Skip to content HOME CREDIT CARDS RESOURCES TOOLS REVIEWS AIRLINES TRIPS HOTELS BOOK A TRIP ABOUT HOME CREDIT CARDS RESOURCES TOOLS REVIEWS AIRLINES TRIPS HOTELS BOOK A TRIP ABOUT \u00d7 Credit Cards Deals Amex Off\u2026",
+      "source": "https://boardingarea.com/?blog-post=amex-offers-alaska-airlines-spend-300-get-60-back",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "new-marriott-boundless-offer-125-000-points-50k-free-night-certificate",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "New Marriott Boundless Offer: 125,000 points + 50K free night certificate",
+      "cover": "https://boardingarea.com/wp-content/uploads/2025/09/249c8ecef14756e47b846d846c566cd3.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/new-marriott-boundless-offer-125-000-points-50k-free-night-certificate/",
+      "excerpt": "New Marriott Boundless Offer: 125,000 points + 50K free night certificate back to top Facebook Instagram RSS Twitter Beginner\u2019s Guide Best Credit Card Offers Best Offers Card Exploration Tool (Beta) All Credit Cards American Express Bank Of America Barclays Capital One Chase C\u2026",
+      "source": "https://boardingarea.com/?blog-post=new-marriott-boundless-offer-125000-points-50k-free-night-certificate",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "earn-up-to-125k-points-and-a-free-night-certificate-with-limited-time",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Earn up to 125K points and a free night certificate with limited-time Marriott Bonvoy card offers",
+      "cover": "https://runway-media-production.global.ssl.fastly.net/us/originals/2025/03/20250310_JW-Marriott-Orlando-Grande-Lakes_ARotondo-lazy-river.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/earn-up-to-125k-points-and-a-free-night-certificate-with-limited-time/",
+      "excerpt": "Current offers on Marriott Bonvoy cobranded credit cards - The Points Guy Skip to content Menu Go to Home Page Subscribe Advertiser disclosure Search The Points Guy Advertiser disclosure ADVERTISEMENT News Earn up to 125K points and a free night certificate with limited-time M\u2026",
+      "source": "https://thepointsguy.com/credit-cards/marriott-bonvoy-current-offers/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "marriott-bonvoy-launches-2-new-credit-card-bonuses-offers-of-up-to-125",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Marriott Bonvoy Launches 2 New Credit Card Bonuses: Offers of up to 125K Points + 1 Free Night Available",
+      "cover": "https://upgradedpoints.com/wp-content/uploads/2025/03/Marriott-Credit-Cards-in-a-Yellow-Wallet-Upgraded-Points-LLC.jpg.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/marriott-bonvoy-launches-2-new-credit-card-bonuses-offers-of-up-to-125/",
+      "excerpt": "Elevated Marriott Bonvoy Card Bonuses: Get up to 125K Points News Credit Cards Credit Cards By Issuer Amex Chase Capital One Citi Mastercard Visa All Credit Card Issuers Best Cards By Type Best Cards Travel Airline Hotel Sign Up Bonus Cash Back Zero Interest Lounge Access Luxu\u2026",
+      "source": "https://upgradedpoints.com/news/marriott-credit-card-offer/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "new-wyndham-rewards-promotion-offers-up-to-30-000-bonus-points-ends-ja",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "New Wyndham Rewards Promotion Offers up to 30,000 Bonus Points [Ends January 20]",
+      "cover": "https://upgradedpoints.com/wp-content/uploads/2022/09/Wyndham-Grand-Crete-Mirabello-aerial-view.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/new-wyndham-rewards-promotion-offers-up-to-30-000-bonus-points-ends-ja/",
+      "excerpt": "Wyndham Rewards Promotion: Up to 30K Points [Ends Jan. 20] News Credit Cards Credit Cards By Issuer Amex Chase Capital One Citi Mastercard Visa All Credit Card Issuers Best Cards By Type Best Cards Travel Airline Hotel Sign Up Bonus Cash Back Zero Interest Lounge Access Luxury\u2026",
+      "source": "https://upgradedpoints.com/news/wyndham-bonus-points-promo/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "american-airlines-offering-a-juicy-opportunity-to-match-to-aadvantage",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "American Airlines offering a juicy opportunity to match to AAdvantage Elite Status\u2026with a catch",
+      "cover": "https://boardingarea.com/wp-content/uploads/2025/09/afbd9a5654e420257ab627e18ea968ae.png",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/american-airlines-offering-a-juicy-opportunity-to-match-to-aadvantage/",
+      "excerpt": "American Airlines offering a juicy opportunity to match to AAdvantage Elite Status...with a catch back to top Facebook Instagram RSS Twitter Beginner\u2019s Guide Best Credit Card Offers Best Offers Card Exploration Tool (Beta) All Credit Cards American Express Bank Of America Barc\u2026",
+      "source": "https://boardingarea.com/?blog-post=american-airlines-offering-a-juicy-opportunity-to-match-to-aadvantage-elite-statuswith-a-catch",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "more-generous-capital-one-shopping-offers-50-on-50-lululemon-20-ihg-30",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "More generous Capital One Shopping offers: $50 on $50 Lululemon, 20% IHG, 30% Hilton, 18% Choice & more",
+      "cover": "https://boardingarea.com/wp-content/uploads/2025/09/2a7c6dcb0344a6cffc09d3e1bc203f8f.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/more-generous-capital-one-shopping-offers-50-on-50-lululemon-20-ihg-30/",
+      "excerpt": "More generous Capital One Shopping offers: $50 on $50 Lululemon, 20% IHG, 30% Hilton, 18% Choice & more back to top Facebook Instagram RSS Twitter Beginner\u2019s Guide Best Credit Card Offers Best Offers Card Exploration Tool (Beta) All Credit Cards American Express Bank Of Americ\u2026",
+      "source": "https://boardingarea.com/?blog-post=more-generous-capital-one-shopping-offers-50-on-50-lululemon-20-ihg-30-hilton-18-choice-more",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "save-on-travel-for-1-day-only-with-retailmenot-book-on-september-30-20",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Save on Travel for 1 Day Only With RetailMeNot [Book on September 30]",
+      "cover": "https://upgradedpoints.com/wp-content/uploads/2025/09/Miami-Beach-Chair-Setup.jpg",
+      "canonical": "https://archive.aventuroo.com/travel/tips-planning/save-on-travel-for-1-day-only-with-retailmenot-book-on-september-30-20/",
+      "excerpt": "Save on Travel for 1 Day Only With RetailMeNot [September 30] News Credit Cards Credit Cards By Issuer Amex Chase Capital One Citi Mastercard Visa All Credit Card Issuers Best Cards By Type Best Cards Travel Airline Hotel Sign Up Bonus Cash Back Zero Interest Lounge Access Lux\u2026",
+      "source": "https://upgradedpoints.com/news/retailmenot-cash-back-travel-purchases/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    }
+  ]
+}

--- a/data/hot/shopping/vpn-security/index.json
+++ b/data/hot/shopping/vpn-security/index.json
@@ -1,0 +1,76 @@
+{
+  "items": [
+    {
+      "slug": "arizona-age-verification-law-proton-said-to-be-robust-enough-to-handle",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Arizona age verification law \u2013 Proton said to be \"robust enough\" to handle any VPN surge",
+      "cover": "https://cdn.mos.cms.futurecdn.net/FmdXmzsDAiMZqZvPaXZgq5-1280-80.png",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/arizona-age-verification-law-proton-said-to-be-robust-enough-to-handle/",
+      "excerpt": "Arizona age verification law \u2013 Proton said to be \"robust enough\" to handle any VPN surge | TechRadar Skip to main content Open menu TechRadar the technology experts US Edition Asia Singapore Europe Danmark Suomi Norge Sverige UK Italia Nederland Belgi\u00eb (Nederlands) France Deut\u2026",
+      "source": "https://www.techradar.com/vpn/vpn-privacy-security/arizona-age-verification-law-proton-said-to-be-robust-enough-to-handle-any-vpn-surge",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "norton-vpn-review-a-vpn-that-fails-to-meet-norton-s-standards-2025-09",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "Norton VPN review: A VPN that fails to meet Norton's standards",
+      "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2025-08%2F0d36ee70-7861-11f0-b7d3-c09cebb7d9c7&resize=1400%2C787&client=19f2b5e49a271b2bde77&signature=0d7d72a60f5fd1245390c5f5530290ab39149601",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/norton-vpn-review-a-vpn-that-fails-to-meet-norton-s-standards-2025-09/",
+      "excerpt": "Norton VPN review: A VPN that fails to meet Norton's standards Sign in Advertisement Advertisement Advertisement Trending : DJI Osmo Nano review iPhone 17 review: Closer to Pro iPhone 17 Pro and Pro Max review iOS 26: Is your iPhone is compatible? October Prime Day: Best early\u2026",
+      "source": "https://www.engadget.com/cybersecurity/vpn/norton-vpn-review-a-vpn-that-fails-to-meet-nortons-standards-170037086.html?src=rss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "surfshark-vpn-review-a-fast-vpn-for-casual-users-2025-09-25",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Surfshark VPN review: A fast VPN for casual users",
+      "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2025-07%2F60bf4d70-68b3-11f0-aaff-bddfb8a2dd62&resize=1400%2C787&client=19f2b5e49a271b2bde77&signature=642ecf04d7d1589a2eca7ec30d0b901189bbc071",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/surfshark-vpn-review-a-fast-vpn-for-casual-users-2025-09-25/",
+      "excerpt": "Surfshark VPN review: A fast VPN for casual users Sign in Advertisement Advertisement Advertisement Trending : DJI Osmo Nano review iPhone 17 review: Closer to Pro iPhone 17 Pro and Pro Max review iOS 26: Is your iPhone is compatible? October Prime Day: Best early deals Cybers\u2026",
+      "source": "https://www.engadget.com/cybersecurity/vpn/surfshark-vpn-review-a-fast-vpn-for-casual-users-170022675.html?src=rss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "leave-vpns-alone-thursday-s-day-of-action-against-possible-vpn-bans-20",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "'Leave VPNs Alone': Thursday's Day of Action Against Possible VPN Bans",
+      "cover": "https://www.cnet.com/a/img/resize/05099f8066c52d479e8471809cbfd8c82d0df038/hub/2025/01/16/006d8f2f-dd85-4977-a537-7e285e6cf167/vpn-logo-on-phone-gettyimages-2151954471.jpg?auto=webp&fit=crop&height=614&width=1600",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/leave-vpns-alone-thursday-s-day-of-action-against-possible-vpn-bans-20/",
+      "excerpt": "'Leave VPNs Alone': Thursday's Day of Action Against Possible VPN Bans - CNET Your Guide To a Better Future News AI Tech VPN Phones Laptops Audio TV Services & Software Computers All Tech Home Home Security Smart Home Kitchen & Household Yard & Outdoors Home Internet All Home \u2026",
+      "source": "https://www.cnet.com/tech/services-and-software/leave-vpns-alone-todays-vpn-day-of-action-protests-possible-bans/#ftag=CADf328eec",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "expressvpn-review-2025-fast-speeds-and-a-low-learning-curve-2025-09-25",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "ExpressVPN review 2025: Fast speeds and a low learning curve",
+      "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2023-07%2F44ac0880-2a1c-11ee-afde-930cabc5d8ba&resize=1400%2C934&client=19f2b5e49a271b2bde77&signature=3b522e25913d0a1d77eecc40c835c9f1f2e0b19f",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/expressvpn-review-2025-fast-speeds-and-a-low-learning-curve-2025-09-25/",
+      "excerpt": "ExpressVPN review 2025: Fast speeds and a low learning curve Sign in Advertisement Advertisement Advertisement Trending : DJI Osmo Nano review iPhone 17 review: Closer to Pro iPhone 17 Pro and Pro Max review iOS 26: Is your iPhone is compatible? October Prime Day: Best early d\u2026",
+      "source": "https://www.engadget.com/cybersecurity/vpn/expressvpn-review-2025-fast-speeds-and-a-low-learning-curve-160052884.html?src=rss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "nordvpn-review-2025-innovative-features-a-few-missteps-2025-09-24",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "NordVPN review 2025: Innovative features, a few missteps",
+      "cover": "https://o.aolcdn.com/images/dims?image_uri=https%3A%2F%2Fs.yimg.com%2Fos%2Fcreatr-uploaded-images%2F2025-06%2Fbbe79c10-487f-11f0-9fed-51cbb087000c&resize=1400%2C1301&client=19f2b5e49a271b2bde77&signature=cef45a3a9e88677f5c2a7a2f47b8831b1f085246",
+      "canonical": "https://archive.aventuroo.com/tech-ai/innovation-gadgets/nordvpn-review-2025-innovative-features-a-few-missteps-2025-09-24/",
+      "excerpt": "NordVPN review 2025: Innovative features, a few missteps Sign in Advertisement Advertisement Advertisement Trending : DJI Osmo Nano review iPhone 17 review: Closer to Pro iPhone 17 Pro and Pro Max review iOS 26: Is your iPhone is compatible? October Prime Day: Best early deals\u2026",
+      "source": "https://www.engadget.com/cybersecurity/vpn/nordvpn-review-2025-innovative-features-a-few-missteps-163000578.html?src=rss",
+      "contact_url": "https://www.aventuroo.com/contact"
+    }
+  ]
+}

--- a/data/hot/summary.json
+++ b/data/hot/summary.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2025-11-13",
   "per_page": 12,
-  "total_items": 4133,
+  "total_items": 4195,
   "parents": [
     {
       "parent": "business-finance",
@@ -351,6 +351,55 @@
           "slug": "travel/trip-ideas",
           "items": 39,
           "pages": 4
+        }
+      ]
+    },
+    {
+      "parent": "shopping",
+      "items": 62,
+      "pages": 6,
+      "children": [
+        {
+          "child": "general",
+          "slug": "shopping/general",
+          "items": 12,
+          "pages": 1
+        },
+        {
+          "child": "marketplaces",
+          "slug": "shopping/marketplaces",
+          "items": 8,
+          "pages": 1
+        },
+        {
+          "child": "multi-merchant",
+          "slug": "shopping/multi-merchant",
+          "items": 8,
+          "pages": 1
+        },
+        {
+          "child": "subscriptions",
+          "slug": "shopping/subscriptions",
+          "items": 9,
+          "pages": 1
+        },
+        {
+          "child": "tech-deals",
+          "slug": "shopping/tech-deals",
+          "items": 9,
+          "pages": 1
+        },
+        {
+          "child": "travel-deals",
+          "slug": "shopping/travel-deals",
+          "items": 10,
+          "pages": 1
+        },
+        {
+          "child": "vpn-security",
+          "slug": "shopping/vpn-security",
+          "items": 6,
+          "pages": 1
         }
       ]
     }

--- a/data/menu.json
+++ b/data/menu.json
@@ -275,6 +275,43 @@
       ]
     },
     {
+      "title": "Shopping",
+      "slug": "shopping",
+      "href": "/category.html?cat=shopping",
+      "children": [
+        {
+          "title": "Tech Deals",
+          "slug": "tech-deals",
+          "href": "/category.html?cat=tech-deals"
+        },
+        {
+          "title": "Subscriptions",
+          "slug": "subscriptions",
+          "href": "/category.html?cat=subscriptions"
+        },
+        {
+          "title": "Travel Deals",
+          "slug": "travel-deals",
+          "href": "/category.html?cat=travel-deals"
+        },
+        {
+          "title": "VPN & Security",
+          "slug": "vpn-security",
+          "href": "/category.html?cat=vpn-security"
+        },
+        {
+          "title": "Marketplaces",
+          "slug": "marketplaces",
+          "href": "/category.html?cat=marketplaces"
+        },
+        {
+          "title": "Multi-Merchant",
+          "slug": "multi-merchant",
+          "href": "/category.html?cat=multi-merchant"
+        }
+      ]
+    },
+    {
       "title": "Archive",
       "href": "/archive.html",
       "slug": "archive"

--- a/data/taxonomy.json
+++ b/data/taxonomy.json
@@ -30,6 +30,10 @@
       "title": "News"
     },
     {
+      "slug": "shopping",
+      "title": "Shopping"
+    },
+    {
       "slug": "tech-ai",
       "title": "Tech & AI"
     },
@@ -48,6 +52,7 @@
         "food-drink",
         "lifestyle",
         "news",
+        "shopping",
         "travel"
       ]
     },
@@ -250,6 +255,36 @@
       "slug": "trip-ideas",
       "title": "Trip Ideas",
       "group": "travel"
+    },
+    {
+      "slug": "tech-deals",
+      "title": "Tech Deals",
+      "group": "shopping"
+    },
+    {
+      "slug": "subscriptions",
+      "title": "Subscriptions",
+      "group": "shopping"
+    },
+    {
+      "slug": "travel-deals",
+      "title": "Travel Deals",
+      "group": "shopping"
+    },
+    {
+      "slug": "vpn-security",
+      "title": "VPN & Security",
+      "group": "shopping"
+    },
+    {
+      "slug": "marketplaces",
+      "title": "Marketplaces",
+      "group": "shopping"
+    },
+    {
+      "slug": "multi-merchant",
+      "title": "Multi-Merchant",
+      "group": "shopping"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a Shopping navigation group with six subcategories to the menu and taxonomy hierarchies
- seed Shopping hot shard indexes for general, deals, subscriptions, marketplaces, and VPN content using recent posts
- register the new Shopping shards in the hot manifest and summary so pagination includes the new branch

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e9865070833388c3d3a627560164