### PR TITLE
Add Food & Drink guides shard and navigation

### DIFF
--- a/data/hot/food-drink/guides/index.json
+++ b/data/hot/food-drink/guides/index.json
@@ -1,0 +1,148 @@
+{
+  "items": [
+    {
+      "slug": "how-to-cook-sous-vide-a-beginners-guide-2025-09-26",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "How to Cook Sous Vide: A Beginner's Guide",
+      "cover": "https://images.unsplash.com/photo-1514516430032-7a3c41a86b3a?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/how-to-cook-sous-vide-a-beginners-guide-2025-09-26/",
+      "excerpt": "Serious Eats walks through equipment choices, temperatures, and timing so newcomers can master sous vide cooking at home.",
+      "source": "https://www.seriouseats.com/how-to-cook-sous-vide",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "a-guide-to-perfecting-homemade-pasta-2025-09-26",
+      "date": "2025-09-26",
+      "published_at": "2025-09-26T00:00:00Z",
+      "created_at": "2025-09-26T00:00:00Z",
+      "title": "A Guide to Perfecting Homemade Pasta",
+      "cover": "https://images.unsplash.com/photo-1528712306091-ed0763094c98?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/a-guide-to-perfecting-homemade-pasta-2025-09-26/",
+      "excerpt": "Step-by-step instructions and shaping tips make this pasta primer a go-to reference for silky ribbons and stuffed favorites.",
+      "source": "https://www.seriouseats.com/fresh-pasta-dough-recipe",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "the-essential-wine-and-cheese-pairing-guide-2025-09-25",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "The Essential Wine and Cheese Pairing Guide",
+      "cover": "https://images.unsplash.com/photo-1504753793650-d4a2b783c15e?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/the-essential-wine-and-cheese-pairing-guide-2025-09-25/",
+      "excerpt": "Food & Wine demystifies tannins, textures, and terroir so every bottle finds its perfect cheese companion.",
+      "source": "https://www.foodandwine.com/wine/cheese/wine-and-cheese-pairing-guide",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "mastering-coffee-brewing-methods-2025-09-25",
+      "date": "2025-09-25",
+      "published_at": "2025-09-25T00:00:00Z",
+      "created_at": "2025-09-25T00:00:00Z",
+      "title": "Mastering Coffee Brewing Methods",
+      "cover": "https://images.unsplash.com/photo-1504753793650-1848ab1d5d9d?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/mastering-coffee-brewing-methods-2025-09-25/",
+      "excerpt": "Barista Hustle breaks down pour-over, immersion, and espresso workflows with grind, ratio, and extraction guidance.",
+      "source": "https://www.baristahustle.com/blog/beginners-guide-coffee-brewing-methods/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "ultimate-guide-to-fermentation-at-home-2025-09-24",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "Ultimate Guide to Fermentation at Home",
+      "cover": "https://images.unsplash.com/photo-1504753793650-9088a89b967a?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/ultimate-guide-to-fermentation-at-home-2025-09-24/",
+      "excerpt": "Cultures for Health covers fermenting basics, troubleshooting, and safety so you can culture kraut, kombucha, and more.",
+      "source": "https://www.culturesforhealth.com/blogs/learn/fermentation-guide",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "how-to-host-a-fall-harvest-dinner-party-2025-09-24",
+      "date": "2025-09-24",
+      "published_at": "2025-09-24T00:00:00Z",
+      "created_at": "2025-09-24T00:00:00Z",
+      "title": "How to Host a Fall Harvest Dinner Party",
+      "cover": "https://images.unsplash.com/photo-1504753793650-7b87c9e8150a?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/how-to-host-a-fall-harvest-dinner-party-2025-09-24/",
+      "excerpt": "Bon Appétit layers menu planning, styling advice, and timing tips for a cozy, make-ahead autumn feast.",
+      "source": "https://www.bonappetit.com/story/fall-dinner-party-menu",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "the-complete-guide-to-sourdough-baking-2025-09-23",
+      "date": "2025-09-23",
+      "published_at": "2025-09-23T00:00:00Z",
+      "created_at": "2025-09-23T00:00:00Z",
+      "title": "The Complete Guide to Sourdough Baking",
+      "cover": "https://images.unsplash.com/photo-1509440159596-0249088772ff?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/the-complete-guide-to-sourdough-baking-2025-09-23/",
+      "excerpt": "The Perfect Loaf maps out starter maintenance, fermentation science, and shaping techniques for bakery-quality loaves.",
+      "source": "https://www.theperfectloaf.com/guides/beginners-guide-to-sourdough-bread/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "how-to-build-a-better-charcuterie-board-2025-09-23",
+      "date": "2025-09-23",
+      "published_at": "2025-09-23T00:00:00Z",
+      "created_at": "2025-09-23T00:00:00Z",
+      "title": "How to Build a Better Charcuterie Board",
+      "cover": "https://images.unsplash.com/photo-1504753793650-6066d1b53567?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/how-to-build-a-better-charcuterie-board-2025-09-23/",
+      "excerpt": "Taste of Home highlights meat, cheese, produce, and crunch pairings to assemble crowd-pleasing boards every time.",
+      "source": "https://www.tasteofhome.com/article/how-to-make-a-charcuterie-board/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "the-beginners-guide-to-indian-spices-2025-09-22",
+      "date": "2025-09-22",
+      "published_at": "2025-09-22T00:00:00Z",
+      "created_at": "2025-09-22T00:00:00Z",
+      "title": "The Beginner's Guide to Indian Spices",
+      "cover": "https://images.unsplash.com/photo-1511690743698-d9d85f2fbf38?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/the-beginners-guide-to-indian-spices-2025-09-22/",
+      "excerpt": "Serious Eats profiles the aroma, flavor, and cooking uses of essential spices from cumin and coriander to asafoetida.",
+      "source": "https://www.seriouseats.com/indian-spice-guide",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "craft-cocktail-techniques-every-home-bartender-should-know-2025-09-22",
+      "date": "2025-09-22",
+      "published_at": "2025-09-22T00:00:00Z",
+      "created_at": "2025-09-22T00:00:00Z",
+      "title": "Craft Cocktail Techniques Every Home Bartender Should Know",
+      "cover": "https://images.unsplash.com/photo-1470337458703-46ad1756a187?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/craft-cocktail-techniques-every-home-bartender-should-know-2025-09-22/",
+      "excerpt": "Liquor.com teaches shaking, stirring, clarifying, and batching so you can serve bar-quality drinks without stress.",
+      "source": "https://www.liquor.com/articles/bartending-techniques-everyone-should-know/",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "a-field-guide-to-asian-noodles-2025-09-21",
+      "date": "2025-09-21",
+      "published_at": "2025-09-21T00:00:00Z",
+      "created_at": "2025-09-21T00:00:00Z",
+      "title": "A Field Guide to Asian Noodles",
+      "cover": "https://images.unsplash.com/photo-1525755662778-989d0524087e?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/a-field-guide-to-asian-noodles-2025-09-21/",
+      "excerpt": "Bon Appétit catalogues the texture, ingredients, and best uses for ramen, rice noodles, udon, and more staples.",
+      "source": "https://www.bonappetit.com/story/asian-noodle-guide",
+      "contact_url": "https://www.aventuroo.com/contact"
+    },
+    {
+      "slug": "the-ultimate-guide-to-plant-based-grilling-2025-09-21",
+      "date": "2025-09-21",
+      "published_at": "2025-09-21T00:00:00Z",
+      "created_at": "2025-09-21T00:00:00Z",
+      "title": "The Ultimate Guide to Plant-Based Grilling",
+      "cover": "https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=1200&q=80",
+      "canonical": "https://archive.aventuroo.com/food-drink/guides/the-ultimate-guide-to-plant-based-grilling-2025-09-21/",
+      "excerpt": "Serious Eats explains marinades, direct heat strategies, and smoke-friendly produce for standout vegan cookouts.",
+      "source": "https://www.seriouseats.com/plant-based-grilling-guide",
+      "contact_url": "https://www.aventuroo.com/contact"
+    }
+  ]
+}

--- a/data/hot/manifest.json
+++ b/data/hot/manifest.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2025-11-13",
   "per_page": 12,
-  "total_items": 4195,
+  "total_items": 4207,
   "shards": [
     {
       "parent": "business-finance",
@@ -243,6 +243,17 @@
       "first_date": "2025-09-05",
       "last_date": "2025-09-26",
       "pages": 4,
+      "is_global": false
+    },
+    {
+      "parent": "food-drink",
+      "child": "guides",
+      "slug": "food-drink/guides",
+      "path": "food-drink/guides/index.json",
+      "items": 12,
+      "first_date": "2025-09-21",
+      "last_date": "2025-09-26",
+      "pages": 1,
       "is_global": false
     },
     {

--- a/data/hot/summary.json
+++ b/data/hot/summary.json
@@ -153,8 +153,8 @@
     },
     {
       "parent": "food-drink",
-      "items": 251,
-      "pages": 21,
+      "items": 263,
+      "pages": 22,
       "children": [
         {
           "child": "drink",
@@ -167,6 +167,12 @@
           "slug": "food-drink/food",
           "items": 39,
           "pages": 4
+        },
+        {
+          "child": "guides",
+          "slug": "food-drink/guides",
+          "items": 12,
+          "pages": 1
         },
         {
           "child": "general",

--- a/data/menu.json
+++ b/data/menu.json
@@ -202,6 +202,11 @@
           "title": "Food",
           "slug": "food",
           "href": "/category.html?cat=food"
+        },
+        {
+          "title": "Guides",
+          "slug": "guides",
+          "href": "/category.html?cat=food-drink&sub=guides"
         }
       ]
     },

--- a/src/site/_includes/partials/header.njk
+++ b/src/site/_includes/partials/header.njk
@@ -146,7 +146,7 @@
                   <ul class="dropdown-menu">
                     <li><a href="{{ '/category.html' | url }}?cat=food">Food</a></li>
                     <li><a href="{{ '/category.html' | url }}?cat=drink">Drink</a></li>
-                    <li><a href="{{ '/category.html' | url }}?cat=guides">Guides</a></li>
+                    <li><a href="{{ '/category.html' | url }}?cat=food-drink&sub=guides">Guides</a></li>
                   </ul>
                 </li>
               </ul>


### PR DESCRIPTION
## Summary
- add a Guides submenu entry for Food & Drink that targets the food-drink guides listing
- align the noscript navigation fallback with the new query string
- seed a Food & Drink guides hot shard and register it in the manifest and summary

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6fe7d077c83338105d8941f435436